### PR TITLE
add community page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -50,7 +50,7 @@
   side: left
   dropdown:
   - title: "Get Involved"
-    url: "/join/"
+    url: "/community/"
   - title: "Become a Member Organization"
     url: "/membership/"
   - title: "Our Members"

--- a/pages/community.md
+++ b/pages/community.md
@@ -2,12 +2,13 @@
 layout: page-fullwidth
 title: "Join our Community"
 permalink: /community/
+excerpt: Find ways to engage with the global Carpentries Community.
 ---
 
 The Carpentries works to help institutions and individuals spread skills for data analysis, computational thinking, 
 and research software development through building local and global communities of practice.
 
-### We do this through:
+## We do this through:
 
 * Overseeing the training and certification of [Instructors](#instructors)
 * Maintaining global communities of practice:
@@ -22,25 +23,25 @@ and research software development through building local and global communities 
 	* Infrastructure - those who work to support our infrastructure
 	* [Workshop administrators](#workshop-administrators) - those who coordinate workshops regionally
 	* [Code of conduct](#code-of-conduct-committee) - those who keep our community friendly and welcoming
-	
+
 * Supporting regional communities of practice:
-	* [Carpentries en Latinoamérica](#carpentries-en-latinoamerica) - building Carpentry community in Latin America
+	* [Carpentries en Latinoamérica](#carpentries-en-latinoamérica) - building Carpentry community in Latin America
 	* [African Task Force](#african-task-force) - building Carpentry community in Africa
-	
-* Organizing in-person meetups to keep our community strong and connected
-* [CarpentryCon](#carpentry-con) 
+
+* Keeping our community strong and connected through meetups (virtual and in-person) and interest-specific mailing lists
+    * [CarpentryCon](#carpentry-con) - our annual in-person meetup for our global community
+    * [Community calendar](#community-events)
+    * [Networking opportunities](#network)
+    * [Mailing lists](#mailing-lists)
 
 
 ### Instructors
 Carpentry Instructors are the core of our community. Instructors organize and teach Carpentry workshops to spread data literacy and programmatic skills both locally and globally. Members of our Instructor community work together to actively grow their instructional and technical skills. Becoming an Instructor is a great step to leveling-up your own technical skills and helps you to become a more effective technical communicator. 
 
-[Training](http://carpentries.github.io/instructor-training/)
-Responsibilities: 
-
-Teach at least one workshop within your first year as an Instructor. Teach at least one workshop every two years to stay a voting member of the Carpentry community.
-
-* [Apply to join](https://amy.software-carpentry.org/forms/request_training/) 
-* [Contact](mailto:ebecker@carpentries.org)
+* [Training materials](http://carpentries.github.io/instructor-training/)
+* Responsibilities: Teach at least one workshop within your first year as an Instructor. Teach at least one workshop every two years to stay a voting member of the Carpentry community.
+* [Apply to become an Instructor](https://amy.software-carpentry.org/forms/request_training/) 
+* For more information contact [Erin Becker](mailto:ebecker@carpentries.org).
 
 ### Mentoring
 
@@ -50,77 +51,72 @@ project-based small mentorship groups.
 
 #### Mentoring Groups
 
-* [Training](http://docs.carpentries.org/topic_folders/mentoring/mentoring-groups.html#carpentries-mentoring-groups-outline)
-* [Duties](http://docs.carpentries.org/topic_folders/mentoring/mentor-agreement.html)
-* [Apply to join]
-* [Mentee Application](https://goo.gl/forms/qeX1CW1HVOOkqhwi2)
-* [Mentor Application](https://goo.gl/forms/zeP2FpP1HuLAMUow1)
-* [Mentor Mailing list](https://groups.google.com/a/carpentries.org/forum/#!forum/carpentries-mentors)
-* [Contact](mailto:kariljordan@carpentries.org)
+Mentoring Groups support instructors in a variety of ways. Whether you are a new instructor preparing to teach your first workshop, a seasoned instructor hoping to launch workshops in a new community, or an instructor excited about getting involved with lesson development and maintenance, mentoring groups will help you gain the confidence, technical skills, and teaching skills you need to reach your goal.
+
+* [Training materials](http://docs.carpentries.org/topic_folders/mentoring/mentoring-groups.html)
+* [Duties](http://docs.carpentries.org/topic_folders/mentoring/mentoring-groups.html#mentor-agreement)
+* [Apply to become a Mentee](https://goo.gl/forms/qeX1CW1HVOOkqhwi2)
+* [Apply to become a Mentor](https://goo.gl/forms/zeP2FpP1HuLAMUow1)
+* For more information contact [Kari Jordan](mailto:kariljordan@carpentries.org).
 
 #### Mentoring Subcommittee
 
-* [Training](https://docs.carpentries.org/topic_folders/mentoring/onboarding-document.html)
-* [Duties](https://github.com/carpentries/mentoring/blob/master/roles/README.md)
+The Mentoring Subcommittee supports Instructors as they progress through training, teaching, curriculum development, and other community-related activities. They help promote community-building and networking, by providing virtual spaces where instructors from all over the world can share teaching success stories and discuss teaching strategies.
+
+* [Training materials](http://docs.carpentries.org/topic_folders/mentoring/mentoring-subcommittee.html)
+* [Mentoring Subcommittee roles](http://docs.carpentries.org/topic_folders/mentoring/mentoring-subcommittee-roles.html)
 * [Current members](https://github.com/carpentries/mentoring/blob/master/README.md#current-members)
 * Join: Join the Mentoring Subcommittee by attending our monthly meeting.
 * [Upcoming meetings](http://pad.software-carpentry.org/scf-mentoring)
 * [Mailing list](http://lists.software-carpentry.org/listinfo/mentoring)
 * [Meeting minutes](https://github.com/carpentries/mentoring/tree/master/minutes)
-* [Contact](mailto:tbyhdgs@gmail.com)
+* For more information contact [Toby Hodges](mailto:tbyhdgs@gmail.com).
 
 ### Trainers
 The Trainer community is a group of experienced Instructors who inspire and prepare the next wave of Instructors in our community. They work as a team to maintain and teach the [instructor training curriculum](http://carpentries.github.io/instructor-training/) to prepare prospective Carpentry Instructors to join the community. They showcase and embody the enthusiasm and conduct of our community as they prepare new instructors. Becoming a Trainer lets you scale your impact - sharing your own passion, experience, and enthusiasm with the next generation of Carpentry Instructors.
 
-* [Training](https://carpentries.github.io/trainer-training/)
-* [Duties](http://docs.carpentries.org/topic_folders/instructor_training/trainers_guide.html#trainer-duties)
+* [Training materials](https://carpentries.github.io/trainer-training/)
+* [Duties](http://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html#trainer-agreement)
 * [Current members](https://github.com/carpentries/trainers/blob/master/README.md#current-members)
-* Apply to join - our next Trainer cohort will start training in northern hemisphere Autumn (Fall) 2018. 
+* Apply to join - our next Trainer cohort will start training in northern hemisphere Autumn (Fall) 2018. Watch this space for more information.
 * [Upcoming meetings](http://pad.software-carpentry.org/trainers)
 * [Mailing list](http://lists.software-carpentry.org/listinfo/trainers)
 * [Slack](https://swcarpentry.slack.com/messages/G7A6ED1SA/details/)
 * [Meeting minutes](https://github.com/carpentries/trainers/tree/master/minutes)
-* [Contact](mailto:ebecker@carpentries.org)
+* For more information contact [Erin Becker](mailto:ebecker@carpentries.org).
 
 ### Maintainers
 Carpentry Maintainers work with the community to make sure that lessons stay up-to-date, accurate, functional and cohesive. Maintainers monitor their lesson repository, make sure that pull requests and issues are addressed in a timely manner, and participate in the lesson development cycle including lesson releases. They endeavor to be welcoming and supportive of contributions from all members of the community. This community of practice is a great place to learn to collaborate effectively in Git and GitHub.
 
-* [Training](https://carpentries.github.io/maintainer-onboarding/)
-* [Duties](http://docs.carpentries.org/topic_folders/maintainers/maintainers.html#maintainer-guidelines)
-* [Apply to join](https://docs.google.com/forms/d/e/1FAIpQLSfuSUffza_DrqqMwdokdNtSgNfdxzMSmbwLw8655GU31BXPyg/viewform?usp=sf_link)
+* [Training materials](https://carpentries.github.io/maintainer-onboarding/)
+* [Maintainer guidelines](http://docs.carpentries.org/topic_folders/maintainers/maintainers.html#maintainer-guidelines)
+* [Apply to become a Maintainer](https://docs.google.com/forms/d/e/1FAIpQLSfuSUffza_DrqqMwdokdNtSgNfdxzMSmbwLw8655GU31BXPyg/viewform?usp=sf_link)
 * [Upcoming meetings](http://pad.software-carpentry.org/maintainers)
 * [Mailing list](http://lists.software-carpentry.org/listinfo/maintainers)
 * [Slack](https://swcarpentry.slack.com/messages/C8H5LN44V/details/)
-* [Meeting minutes]()
 * [Contact](mailto:francois@carpentries.org)
 
 ### Lesson Infrastructure
 
-* [Training]()
-* [Duties]()
-* [Current members]()
-* [Apply to join]()
+Members of the Lesson Infrastructure Subcommittee serve as 
+Maintainers for the [Carpentry lesson template](https://github.com/swcarpentry/styles) and [its documentation](https://github.com/swcarpentry/lesson-example), as
+well as for the [Carpentry workshop template](https://github.com/swcarpentry/workshop-template).
+
 * [Upcoming meetings](http://pad.software-carpentry.org/infrastructure-subcommittee)
-* [Mailing list]()
-* [Slack]()
-* [Meeting minutes]()
 * [Contact](mailto:francois@carpentries.org)
 
 ### Curriculum Advisors
 Curriculum Advisors provide high-level guidance on the overall structure of a particular curriculum, 
 including which tools will be taught and which dataset(s) will be used for the lessons. 
 They bring domain-specific expertise to lesson development and help ensure that 
-lesson stay up to date with advances in technology. 
-
-Being a Curriculum Advisor is a great way to keep up-to-date about changes in your field and 
-network with other domain experts in the Carpentries community.
+lesson stay up to date with advances in technology. Being a Curriculum Advisor is a great way to keep up-to-date about changes in your field and 
+network with other domain experts in The Carpentries community.
 
 * [Duties](http://docs.carpentries.org/topic_folders/lesson_development/lesson_development_roles.html)
 * [Current members](http://www.datacarpentry.org/lesson-leadership/)
 * Apply to join: We are not currently seeking new members of the Curriculum Advisory Committees. 
-* Upcoming meetings: The CACs meet bi-annually
-* [Mailing lists]()
-* [Meeting minutes]()
+* Upcoming meetings: Each CAC meets bi-annually in advance of lesson releases.
+* [Meeting minutes](https://github.com/datacarpentry/curriculum-advisors/)
 * [Contact](mailto:ebecker@carpentries.org)
 
 ### Assessment Network
@@ -131,57 +127,51 @@ The Assessment Network is a community for those working on assessment within the
 * [Current members](https://github.com/carpentries/assessment/blob/master/assessment-network/README.md#members)
 * [Upcoming meetings](http://pad.software-carpentry.org/assessment-network)
 * [Meeting minutes](https://github.com/carpentries/assessment/tree/master/assessment-network/minutes)
-* To join or get more information, contact [Kari Jordan](mailto:kariljordan@carpentries.org)
+* [Contact](mailto:kariljordan@carpentries.org)
 
 ### Champions
 
-Need intro para. 
+Carpentry Champions meets quarterly to discuss ways in which they can help support the growth of existing communities and attract new communities to building digital skills capacity at research organizations around the world. Come learn from senior community leaders and get support as you work to build your own local community.
 
 * [Activities](https://github.com/carpentries/champions/blob/master/activities.md) - This community holds quarterly meetings.
-* [Current members]()
-* [Join](https://groups.google.com/a/carpentries.org/forum/#!forum/champions-announce) - join the announcement email list
-* [Upcoming meetings](http://pad.software-carpentry.org/champions) - are added to the etherpad and posted to the meeting announcement list.
+* [Upcoming meetings](http://pad.software-carpentry.org/champions)
+* [Mailing list](https://groups.google.com/a/carpentries.org/forum/#!forum/champions-announce)
 * [Meeting minutes](https://github.com/carpentries/champions/tree/master/meeting-minutes)
-To get involved, please contact [Jonah Duckles](mailto:jduckles@carpentries.org).
+* To get involved contact [Jonah Duckles](mailto:jduckles@carpentries.org).
 
 ### Workshop Administrators
 
-The role of the regional workshop administrator is to be the front face of the Carpentries, promoting our work and our culture in their geographical area.  The workshop administrator will manage workshop logistics, communicate with hosts and instructors, and respond to general inquiries.  As a team, all administrators will  work together to support each other and ensure communities can thrive locally while maintaining quality and consistency globally.
+Regional workshop administrators are the front face of The Carpentries, promoting our work and our culture in their geographical area. They manage workshop logistics, communicate with hosts and Instructors, and respond to general inquiries. Administrators work together to support each other and ensure communities can thrive locally while maintaining quality and consistency globally.
 
 * [Duties](http://docs.carpentries.org/topic_folders/workshop_administration/expectations.html)
 * [Current members](https://github.com/carpentries/workshop-administrators/blob/master/members.md)
 * [Contact](mailto:team@carpentries.org)
 
-### Code of Conduct Committee
+### Code of Conduct Subcommittee
 
-Need intro para.
+The Carpentries is a community-led project. We are committed to creating a friendly and respectful place for learning, teaching and contributing. The Code of Conduct Subcommittee handles reported code of conduct violations and works to keep our community welcoming for all. 
 
-* [Duties](https://github.com/carpentries/policy-actions/blob/master/committee-roles.md)
 * [Current members](https://github.com/orgs/carpentries/teams/policy-subcommittee/members)
 * [Apply to join](https://goo.gl/forms/9NMhirB5wXGZ2FUc2)
 * Upcoming meetings: Meetings are closed to the group for confidentiality reasons.
 * Mailing list: This mailing list is confidential. 
-* [Contact](mailto:kariljordan@carpentries.org)
+* For more information contact [Kari Jordan](mailto:kariljordan@carpentries.org).
 
 ### Carpentries en Latinoamérica
 
-Need into para.
+This group works to build a sustainable and active community in Latin America.
 
-#### Carpentries en Latinoamérica (General Group)
-
-* [Activities]
 * [Mailing list](https://groups.google.com/a/carpentries.org/forum/#!forum/latinoamerica)
-* [Contact](mailto:erinbecker@carpentires.org)
+* For more information contact [Rayna Harris](mailto:rayna.harris@gmail.com).
 
-#### Spanish Translators Team
+### Spanish Translators Team
 
-* [Activities]
-* [Current members]
-* [Join]
-* [Upcoming meetings]()
-* [Mailing list](https://groups.google.com/forum/#!forum/carpentries-traductores)
+The Spanish Translators Team translates and maintains Spanish-language Carpentry lessons. They are a part of the Carpentries en Latinoamérica group.
+
+* To join, sign up for our [mailing list](https://groups.google.com/forum/#!forum/carpentries-traductores).
+* Upcoming meetings - information coming soon!
 * [Meeting minutes](https://github.com/carpentries/latinoamerica/tree/master/traducciones/minutos)
-* [Contact](mailto:erinbecker@carpentires.org)
+* For more information contact [Rayna Harris](mailto:rayna.harris@gmail.com).
 
 ### African Task Force
 
@@ -199,3 +189,229 @@ The Carpentries host an annual meeting for our global community.
 This meeting is organized by the community. [CarpentryCon 2018](http://www.carpentrycon.org/) will be held from
 29 May to 1 June in Dublin, Ireland. If you are interested in helping to organize CarpentryCon 2019, 
 contact [The Carpentries](mailto:team@carpentries.org.au).
+
+###  Network
+
+- Chat to community members in our <a href="https://swc-slack-invite.herokuapp.com/">Slack channel</a>. We have dedicated channels for many of our subcommunities.
+- Follow us on <a href="https://www.facebook.com/carpentries/">Facebook</a>.
+- Attend <a href="http://www.carpentrycon.org/">CarpentryCon 2018</a>, our key community building and networking event.
+- Sign up for <a href="https://carpentries.us14.list-manage.com/subscribe?u=46d7513c798c6bd41e5f58f4a&id=8b4fabb707">CarpentryCon updates</a>.
+- Going to an event? Hoping to connect with other people from the Carpentries? List the event and your your details on our [meetups page](http://pad.software-carpentry.org/swc-events-meetup). 
+- Join and contribute to some of our [mailing lists](#mailing-lists).
+- Read our twice-monthly newsletter, *Carpentry Clippings*. [Sign up to get it by email](http://eepurl.com/cfODMH) or <a href="http://us14.campaign-archive2.com/home/?u=46d7513c798c6bd41e5f58f4a&id=50c3e6d6fe">see past issues</a>.
+
+<hr>
+
+### Community events
+There are many opportunities to join community meetings, sub-committees
+and de-briefing sessions. Find links to them on this <a href="http://pad.software-carpentry.org/pad-of-pads">Etherpad</a>, and subscribe to the calendar below to watch all that is
+going on throughout our community.
+
+<iframe src="https://calendar.google.com/calendar/embed?title=%20Software%20Carpentry%20Community%20Calendar%20&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&amp;color=%231B887A" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+
+<hr> 
+
+### Mailing lists
+
+<table class="table table-striped">
+   
+    <tr>
+        <td colspan="5"><strong>General</strong></td>
+    </tr>
+ 
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/discuss">discuss</a>
+        </td>
+        <td>
+            (archives
+            <a href="{{site.mailing_lists}}/pipermail/discuss/">in Mailman</a>
+            or
+            <a href="http://dir.gmane.org/gmane.education.softwarecarpentry.general">on Gmane</a>)
+        </td>
+        <td>
+            The main channel for discussion of direction and technology.
+        </td>
+        <td>
+            30-40 messages/week
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+  
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/instructors">instructors</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/instructors/">(archives)</a>
+        </td>
+        <td>
+            Advertisements for workshop instructors and helpers.
+        </td>
+        <td>
+            1-2 messages/month
+        </td>
+        <td>
+            moderated
+        </td>
+    </tr>
+  
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/mentoring">mentoring</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/mentoring/">(archives)</a>
+        </td>
+        <td>
+            Working mailing list of the Mentoring subcommittee.
+        </td>
+        <td>
+            5-20 messages/week
+        </td>
+        <td>
+            moderated
+        </td>
+    </tr>
+ 
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/maintainers">maintainers</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/maintainers/">(archives)</a>
+        </td>
+        <td>
+            Working mailing list of the Lesson Development subcommittee
+            (which includes all active lesson maintainers).
+        </td>
+        <td>
+            5-20 messages/week
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/r-discuss">r-discuss</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/r-discuss/">(archives)</a>
+        </td>
+        <td>
+            Discussion of our R lesson and related matters.
+        </td>
+        <td>
+            1-5 messages/week
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+    <tr>
+        <td colspan="5"><strong>Regional</strong></td>
+    </tr>
+    
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/aus-nz">aus-nz</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/aus-nz/">(archives)</a>
+        </td>
+        <td>
+            A sub-list for discussion of activities in Australia and New Zealand.
+        </td>
+        <td>
+            5-20 messages/month
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            <a href="https://groups.google.com/a/carpentries.org/forum/#!forum/latinoamerica">latin-america</a>
+        </td>
+        <td>
+            <a href="https://groups.google.com/a/carpentries.org/forum/#!forum/latinoamerica">(archives)</a>
+        </td>
+        <td>
+            A Google Group for discussion of the Carpentry in Latin America initiative.
+        </td>
+        <td>
+            5-20 messages/month
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/seattle">seattle</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/seattle/">(archives)</a>
+        </td>
+        <td>
+            A sub-list for discussion of activities in the Seattle area.
+        </td>
+        <td>
+            5-10 messages/month
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            <a href="{{site.mailing_lists}}/listinfo/vancouver">vancouver</a>
+        </td>
+        <td>
+            <a href="{{site.mailing_lists}}/pipermail/vancouver/">(archives)</a>
+        </td>
+        <td>
+            A sub-list for discussion of activities in the Vancouver area.
+        </td>
+        <td>
+            5-10 messages/month
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+    <tr>
+        <td colspan="5"><strong>Topic-specific</strong></td>
+    </tr>
+    <tr>
+        <td>
+            <a href="https://groups.google.com/a/carpentries.org/forum/#!forum/assessment-network">assessment</a>
+        </td>
+        <td>
+            <a href="https://groups.google.com/a/carpentries.org/forum/#!forum/assessment-network">(archives)</a>
+        </td>
+        <td>
+            A Google group, led by Dr Kari L. Jordan, for discussion of assessment issues.
+        </td>
+        <td>
+            5-10 messages/month
+        </td>
+        <td>
+            unmoderated
+        </td>
+    </tr>
+
+
+</table>
+
+

--- a/pages/join.md
+++ b/pages/join.md
@@ -25,43 +25,6 @@ still seeking sonsorship to make this a truly global and diverse event that both
 ### Pathways for Engagement - Individuals
   
 Individuals have many ways to get involved in our community. 
-  
-#### Teach the Carpentries
-  
-- Teach or help at <a href="https://software-carpentry.org/workshops/">Software Carpentry</a> 
-or <a href="http://www.datacarpentry.org/workshops/">Data Carpentry</a> workshops. 
-- <a href="https://amy.software-carpentry.org/workshops/request_training/">Apply</a> to become a Carpentries instructor. Instructors develop a great [skill set](https://github.com/carpentries/commons/blob/master/text-for-instructors.md). 
-- Certify as a Trainer. Trainers run instructor training to help others certify as Carpentries Instructors. Calls for people to apply to be Trainers are announced regularly through our blog, our Twitter feed and through email lists. Trainers develop a great [skill set](https://github.com/carpentries/commons/blob/master/text-for-trainers.md). 
-  
-#### Learn the Carpentries
-
-- Attend <a href="https://software-carpentry.org/workshops/">Software Carpentry</a> 
-or <a href="http://www.datacarpentry.org/workshops/">Data Carpentry</a> workshop.
-- Join a [Carpentries mentoring group](https://software-carpentry.org/blog/2018/03/next-round-mentoring.html) as a mentee. 
-
-#### Maintain Lessons
-
-- All Carpentries lessons are actively maintained. Maintainers develop a highly desirable [skill set](https://github.com/carpentries/commons/blob/master/text-for-maintainers.md). Contact us about becoming a Maintainer.
-- Serve on a [Curriculum Advisory Committee](http://www.datacarpentry.org/blog/curriculum-advisory/).
-
-
-#### Build Local Communities
-
-- Join the [Carpentry Champions](http://pad.software-carpentry.org/champions) network. This group meets quarterly to share ideas and experiences around building strong local communities. You can join community calls or join the **#champions** channel on our [Slack](https://swc-slack-invite.herokuapp.com/). 
-- Read or contribute to the [Carpentries Community Cookbook](https://cookbook.carpentries.org/), where we share recipes for community building. See the [repo view](https://github.com/carpentries/community-cookbook).
-
-#### Mentor Others
-
-- Serve on the <a href="https://software-carpentry.org/join/subcom/mentoring/">Mentoring</a> sub-committee.
-- Host [discussion sessions](http://pad.software-carpentry.org/instructor-discussion).
-- Join a [Carpentries mentoring group](https://software-carpentry.org/blog/2018/03/next-round-mentoring.html) as a mentor.
-
-#### Serve on a SubCommittee or Task Force
-
-- We have a range of committees and task forces that people can join. This is a great way to network and meet other people in our community. See [what groups you can join](https://software-carpentry.org/join/subcom_and_tf/).
-- Serve on the <a href="https://software-carpentry.org/join/subcom/mentoring/">Mentoring</a> sub-committee 
-or <a href="https://software-carpentry.org/join/subcom_and_tf/">other committees</a>.
-- Join the <a href="https://github.com/carpentries/carpentrycon">CarpentryCon</a> Task Force or the <a href="https://software-carpentry.org/join/subcom/african-tf/">African Task Force</a>.
 
   
 #### Share Your Knowledge


### PR DESCRIPTION
This implements the community page we have been discussion. Organizational structure provided by @jduckles. Content provided by @maneesha, @kariljordan, @jduckles, @anelda. This replaces the "Join" page and migrates the community calendar and mailing list table from that page. 