### PR TITLE
update color scheme

### DIFF
--- a/_sass/_01_settings_colors.scss
+++ b/_sass/_01_settings_colors.scss
@@ -36,9 +36,9 @@ $ci-6: #A1D044;		// green
 /* Software Carpentry colors
 ---------------------------------------- */
 
-$swc-blue: #557cc3;		// Software Carpentry dark blue
-$swc-blue-light: #688aca;	// Brighter version of Software Carpentry blue
-$swc-blue-med: #9DB6E6;		// Medium version of Software Carpentry blue
+$swc-blue: #071159; //6b7bf3; //557cc3;		// Software Carpentry dark blue
+$swc-blue-med: #6b7bf3; //88aca;	// Brighter version of Software Carpentry blue
+$swc-blue-light: #e3e6fd; //9DB6E6;		// Medium version of Software Carpentry blue
 
 /* Foundation Color Variables
 ------------------------------------------------------------------- */
@@ -77,32 +77,33 @@ $grey-16: #0B0B0B;
 /* Topbar-Navigation
 ------------------------------------------------------------------- */
 
-$topbar-bg-color: #fff;
+$topbar-bg-color: $swc-blue;
 
-$topbar-dropdown-toggle-color: $swc-blue;
+$topbar-dropdown-toggle-color: $grey-1;
+$topbar-dropdown-toggle-alpha: .9;
 
-$topbar-link-color: #000;
-$topbar-link-color-hover: #000;
-$topbar-link-color-active: #000;
-$topbar-link-color-active-hover: #000;
+$topbar-link-color: $grey-1;
+$topbar-link-color-hover: $grey-1;
+$topbar-link-color-active: $grey-15;
+$topbar-link-color-active-hover: $grey-15;
 
-$topbar-dropdown-label-color: $swc-blue-light;
+$topbar-dropdown-label-color: $swc-blue;
 $topbar-dropdown-link-bg-hover: $swc-blue-med;
 
-$topbar-link-bg-active: $swc-blue-med; // Active Navigation Link
+$topbar-link-bg-active: $swc-blue-light; // Active Navigation Link
 $topbar-link-bg-hover: $swc-blue-med;
-$topbar-link-bg-active-hover: $swc-blue-light;
+$topbar-link-bg-active-hover: $swc-blue-med;
 
 $topbar-dropdown-bg: $swc-blue-med; // Background Mobile Navigation
-$topbar-dropdown-link-color: #000;
-$topbar-dropdown-link-bg: $swc-blue-light;
+$topbar-dropdown-link-color: $grey-1;
+$topbar-dropdown-link-bg: $swc-blue;
 
 $topbar-menu-link-color-toggled: $swc-blue;
-$topbar-menu-icon-color-toggled: $swc-blue;
-$topbar-menu-link-color: #000;
-$topbar-menu-icon-color: #000;
-$topbar-menu-link-color-toggled: $swc-blue-med;
-$topbar-menu-icon-color-toggled: $swc-blue-med;
+$topbar-menu-icon-color-toggled: $grey-1;
+$topbar-menu-link-color: $grey-1;
+$topbar-menu-icon-color: $grey-1;
+$topbar-menu-link-color-toggled: $swc-blue;
+$topbar-menu-icon-color-toggled: $grey-1;
 
 
 

--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -69,10 +69,10 @@ body.video cite { color: #fff; }
 ------------------------------------------------------------------- */
 
 #masthead {
-    background-color: $primary-color;
+    background-color: $swc-blue-light;
 }
 #masthead-no-image-header {
-    background-color: $primary-color;
+    background-color: $swc-blue-light;
 }
 #masthead-with-text {
     text-align: center;


### PR DESCRIPTION
I'd like to propose an update to the color scheme used on the website.

The blue currently used doesn't have the same hue as the one used in the logo. I also find that the contrast level is too low. 

The changes proposed here make use of the blue of the logo in the navigation bar, the footer and for the links. See the screenshots below.

Home page before:
![screenshot from 2018-04-19 11-51-21](https://user-images.githubusercontent.com/5502922/39003066-07ace156-43c8-11e8-9fa6-a5058c5234cb.png)

Home page after:
![screenshot from 2018-04-19 11-51-49](https://user-images.githubusercontent.com/5502922/39003092-16f500bc-43c8-11e8-83d4-e39d7ca2b26d.png)

Blog post before:
![screenshot from 2018-04-19 11-52-41](https://user-images.githubusercontent.com/5502922/39003123-3088845e-43c8-11e8-8c9b-edf3e3c05921.png)

Blog post after:
![screenshot from 2018-04-19 11-53-28](https://user-images.githubusercontent.com/5502922/39003183-4d57f542-43c8-11e8-97ba-f9a809c43f61.png)

Menu hover before:
![screenshot from 2018-04-19 11-54-11](https://user-images.githubusercontent.com/5502922/39003329-9e5b081c-43c8-11e8-9e11-0ac95f3a48f5.png)

Menu hover after:
![screenshot from 2018-04-19 11-54-18](https://user-images.githubusercontent.com/5502922/39003340-a584ae0e-43c8-11e8-8965-42af03c5aef8.png)
