### PR TITLE
make blog archive more informative

### DIFF
--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -234,7 +234,7 @@ body.video cite { color: #fff; }
   font-size: rem-calc(13);
   color: scale-color($grey-1, $lightness: 40%);
 }
-  .meta-info a {
+.meta-info a {
     text-decoration: underline;
     color: scale-color($grey-1, $lightness: 40%);
   }
@@ -244,39 +244,52 @@ body.video cite { color: #fff; }
   }
 
 
+  #blog-index .blog-meta p {
+      color: $grey-5;
+      font-size: rem-calc(14);
+  }
 
-/* Jump to top
+  #blog-index p {
+      margin-bottom: 0;
+  }
+
+  #blog-index h4 a {
+      text-decoration: none;
+  }
+
+
+  /* Jump to top
 ------------------------------------------------------------------- */
 
-#up-to-top {
-    padding: 160px 0 10px 0;
-}
-#up-to-top a {
-    font-size: 24px;
-    padding: 5px;
-    border-radius: 3px;
-}
-#up-to-top a:hover {
-    background: $grey-2;
-}
+  #up-to-top {
+      padding: 160px 0 10px 0;
+  }
+  #up-to-top a {
+      font-size: 24px;
+      padding: 5px;
+      border-radius: 3px;
+  }
+  #up-to-top a:hover {
+      background: $grey-2;
+  }
 
 
 
-/* Footer
+  /* Footer
 ------------------------------------------------------------------- */
 
-#footer-content p,
-#footer-content li {
-    font-size: rem-calc(13);
-    font-weight: 300;
-}
+  #footer-content p,
+  #footer-content li {
+      font-size: rem-calc(13);
+      font-weight: 300;
+  }
 
-#footer {
-    padding-top: 30px;
-    padding-bottom: 20px;
-    background: $footer-bg;
-    color: $footer-color;
-    }
+  #footer {
+      padding-top: 30px;
+      padding-bottom: 20px;
+      background: $footer-bg;
+      color: $footer-color;
+  }
 
     #footer a {
         color: $footer-link-color;

--- a/blog/archive.html
+++ b/blog/archive.html
@@ -7,23 +7,52 @@ header:
    image_fullwidth: header_unsplash_8.jpg
 permalink: "blog/archive/"
 ---
-<div id="blog-index" class="row">
-	<div class="small-12 columns t30">
-		<h1>{{ page.title }}</h1>
-		{% if page.teaser %}<p class="teaser">{{ page.teaser }}</p>{% endif %}
+<!-- <div id="blog-index" class="row"> -->
+<!-- 	<div class="small-12 columns t30"> -->
+<!-- 		<h1>{{ page.title }}</h1> -->
+<!-- 		{% if page.teaser %}<p class="teaser">{{ page.teaser }}</p>{% endif %} -->
 
-		<dl class="accordion" data-accordion>
-			{% assign counter = 1 %}
-			{% for post in site.posts limit:1000 %}
-			<dd class="accordion-navigation">
-			<a href="#panel{{ counter }}"><span class="iconfont"></span> {% if post.subheadline %}{{ post.subheadline }} › {% endif %}<strong>{{ post.title }}</strong></a>
-				<div id="panel{{ counter }}" class="content">
-					{% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %}
-					<a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br>
-				</div>
-			</dd>
-			{% assign counter=counter | plus:1 %}
-			{% endfor %}
-		</dl>
-	</div><!-- /.small-12.columns -->
-</div><!-- /.row -->
+<!-- 		<dl class="accordion" data-accordion> -->
+<!-- 			{% assign counter = 1 %} -->
+<!-- 			{% for post in site.posts limit:1000 %} -->
+<!-- 			<dd class="accordion-navigation"> -->
+<!-- 			<a href="#panel{{ counter }}"><span class="iconfont"></span> {{ post.date | date: "%Y-%m-%d" }} {% if post.subheadline %}{{ post.subheadline }} › {% endif %}<strong>{{ post.title }}</strong></a> -->
+<!-- 				<div id="panel{{ counter }}" class="content"> -->
+<!-- 					{% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %} -->
+<!-- 					<a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br> -->
+<!-- 				</div> -->
+<!-- 			</dd> -->
+<!-- 			{% assign counter=counter | plus:1 %} -->
+<!-- 			{% endfor %} -->
+<!-- 		</dl> -->
+<!-- 	</div><\!-- /.small-12.columns -\-> -->
+<!-- </div><\!-- /.row -\-> -->
+
+<div id="blog-index" class="row" >
+  <div class="small-10 columns t30">
+    <h1>{{ page.title }}</h1>
+
+    {% assign counter = 1 %}
+    {% for post in site.posts limit:1000 %}
+
+    <h4><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="Read {{ post.title | escape_once }}"> {{ post.title }} </a> </h4>
+    <p>{{ post.teaser }}</p>
+
+    <div class="blog-meta">
+
+      <p>
+	{% if post.date %}
+	<time class="icon-calendar pr20" datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished"> {{ post.date | date: "%Y-%m-%d" }}</time>
+	{% endif %}
+
+	<span class="icon-edit">
+	  {% for author in post.authors %}<span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name" class="pr20">{{ author }}</span></span>{% endfor %}
+	</span>
+      </p>
+
+    </div>
+
+    {% assign counter=counter | plus:1 %}
+    {% endfor %}
+  </div>
+</div>

--- a/blog/archive.html
+++ b/blog/archive.html
@@ -7,26 +7,7 @@ header:
    image_fullwidth: header_unsplash_8.jpg
 permalink: "blog/archive/"
 ---
-<!-- <div id="blog-index" class="row"> -->
-<!-- 	<div class="small-12 columns t30"> -->
-<!-- 		<h1>{{ page.title }}</h1> -->
-<!-- 		{% if page.teaser %}<p class="teaser">{{ page.teaser }}</p>{% endif %} -->
 
-<!-- 		<dl class="accordion" data-accordion> -->
-<!-- 			{% assign counter = 1 %} -->
-<!-- 			{% for post in site.posts limit:1000 %} -->
-<!-- 			<dd class="accordion-navigation"> -->
-<!-- 			<a href="#panel{{ counter }}"><span class="iconfont"></span> {{ post.date | date: "%Y-%m-%d" }} {% if post.subheadline %}{{ post.subheadline }} › {% endif %}<strong>{{ post.title }}</strong></a> -->
-<!-- 				<div id="panel{{ counter }}" class="content"> -->
-<!-- 					{% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %} -->
-<!-- 					<a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" title="Read {{ post.title | escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br> -->
-<!-- 				</div> -->
-<!-- 			</dd> -->
-<!-- 			{% assign counter=counter | plus:1 %} -->
-<!-- 			{% endfor %} -->
-<!-- 		</dl> -->
-<!-- 	</div><\!-- /.small-12.columns -\-> -->
-<!-- </div><\!-- /.row -\-> -->
 
 <div id="blog-index" class="row" >
   <div class="small-10 columns t30">


### PR DESCRIPTION
To me, the blog archive page provided by "feeling responsive" theme doesn't make sense. I don't see why one would have to click twice to get to the blog post. I'm proposing a redesign that makes the teaser, the authors, and the date of publication visible, and provide 1-click access to the blog post.

Before:

![screenshot from 2018-04-19 15-25-28](https://user-images.githubusercontent.com/5502922/39013619-ebe9b6a6-43e5-11e8-80d9-7d550517ac30.png)

After:
![screenshot from 2018-04-19 15-26-18](https://user-images.githubusercontent.com/5502922/39013666-0e3ed740-43e6-11e8-86d0-f91e495c6e3a.png)
