### PR TITLE
more on teach and learn

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,11 +16,9 @@
     url: "/testimonials/"
     
 - title: "Teach"
-  url: "/workshops/"
+  url: "/teach/"
   side: left
   dropdown:
-  - title: "Our Workshops"
-    url: "/workshops/"
   - title: "Data Carpentry Lessons"
     url: "http://datacarpentry.org/lessons/"
   - title: "Software Carpentry Lessons"
@@ -34,8 +32,8 @@
   url: "/learn/"
   side: left
   dropdown:
-  - title: "Our Audience"
-    url: "/audience/"
+  - title: "Our Workshops"
+    url: "/workshops/"
   - title: "Request a Data Carpentry Workshop"
     url: "http://www.datacarpentry.org/workshops-host/"
   - title: "Request a Software Carpentry Workshop"

--- a/pages/learn.md
+++ b/pages/learn.md
@@ -1,12 +1,24 @@
 ---
 layout: page-fullwidth
-title: "Learning the Carpentries"
+title: "Learning with The Carpentries"
 permalink: /learn/
 ---
 
-Attending a [Carpentries workshop]({{site.url}}/workshops/) builds a great skill set that will help you automate routine tasks, 
-use code to replicate operations or clean up data, and help you on the way to doing robust, reproducible research.
+Attending a [Carpentries workshop](../workshops/) builds the skills and perspectives
+to work more effectively and reproducibily with data and software. You will build a skill set
+that will help you 
+use code to replicate operations or clean up data, automate routine tasks and help you on the way to doing robust, reproducible research, as well as the confidence to continue learning.
 
-Our workshops are designed for beginners. Have a look at some [learner profiles](https://software-carpentry.org/audience/) and read some [testimonials](https://software-carpentry.org/testimonials/) to what others have found useful. 
+We create a friendly environment for learning to empower researchers and enable data driven discovery. All workshop participants are required to abide by our [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) to ensure that all attendees to have a positive learning experience. Workshops are currently designed for people with little to no prior computational experience. Have a look at some [learner profiles](../audience/) and read some [testimonials](../testimonials/) to what others have found useful.
+
+See more information on [the workshops we offer](../workshops), including Software Carpentry and Data Carpentry.
 
 All Carpentries instructors have completed [instructor training](https://docs.carpentries.org/topic_folders/instructor_training/index.html). Once badged as an Instructor, you can go on to teach workshops. Find more about teaching and hosting workshops [in our handbook](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html).
+
+
+
+
+
+
+
+

--- a/pages/teach.md
+++ b/pages/teach.md
@@ -1,0 +1,32 @@
+---
+layout: page-fullwidth
+title: "Teaching with The Carpentries"
+permalink: /teach/
+---
+
+[Carpentries workshops](../workshops/) teach researchers the skills and perspectives
+to work more effectively and reproducibily with data and software. Our
+workshops use open, collaboratively developed [Software Carpentry](https://software-carpentry.org/lessons/) and [Data Carpentry](http://www.datacarpentry.org/lessons/) lessons with materials on topics from data organization to version contrtrol. All our workshops are taught by volunteer instructors, and we have more than 1400
+volunteer instructors around the world.
+
+Becoming an instructor with The Carpentries connects you with a global
+community of instructors who are passionate about helping others learn to
+code and work with data. We use educational pedagogy to inform our teaching
+practices and create accessible and inclusive workshops, including using a [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html), that promotes learning for all participants.
+
+
+
+We offer [instructor training](https://docs.carpentries.org/topic_folders/instructor_training/index.html) to train people in how to teach Carpentries workshops, including educational pedagogy and Carpentries-specific information. 
+
+
+Find out how to [become an instructor](../become-instructor/) and join The
+Carpentries community of instructors or [become an Organizational Member](../membership/) to grow a local community of instructors in your organization.
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- Added some more content to the 'learn' page.
- Moved 'Our Workshops' menu item to 'Learn'
- Added a page 'Teach' for the landing page for 'Teach' rather than 'Our workshops' that includes an overview of teaching with The Carpentries.