### PR TITLE
add toc on community page

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -5,6 +5,20 @@ permalink: /community/
 excerpt: Find ways to engage with the global Carpentries Community, including taking part in committees and taskforces.
 ---
 
+<div class="row">
+<div class="medium-4 medium-push-8 columns" markdown="1">
+<div class="panel radius" markdown="1">
+**Table of Contents**
+{: #toc }
+*  TOC
+{:toc}
+</div>
+</div><!-- /.medium-4.columns -->
+
+
+
+<div class="medium-8 medium-pull-4 columns" markdown="1">
+
 The Carpentries works to help institutions and individuals spread skills for data analysis, computational thinking, 
 and research software development through building local and global communities of practice.
 
@@ -415,3 +429,6 @@ going on throughout our community.
 </table>
 
 
+
+</div><!-- /.medium-8.columns -->
+</div><!-- /.row -->


### PR DESCRIPTION
To make it easier to navigate the long community page, how about we add a table of content to give an overview of the different facets of the community?

(this is just of proof of concept, wording/formatting of page will need to be tweaked to make the table of content more organized)
![screenshot from 2018-04-26 09-19-31](https://user-images.githubusercontent.com/5502922/39308256-fcbfd38c-4932-11e8-8144-9e613de21f6b.png)
