### PR TITLE
Update trainers.html

### DIFF
--- a/pages/trainers.html
+++ b/pages/trainers.html
@@ -13,15 +13,17 @@ excerpt: Trainers prepare new Instructors to teach in our global Carpentries Com
 The Carpentries Trainer community comprises a group of experienced Instructors who inspire and prepare
 the next wave of Instructors in our community. They work as a team to maintain and teach the
 <a href="https://carpentries.github.io/instructor-training/">instructor training curriculum</a> to
-prepare prospective Carpentry Instructors to join the community. They showcase and embody the
-enthusiasm and conduct of our community as they prepare new Instructors. Becoming a Trainer
-lets you scale your impact - sharing your own passion, experience, and enthusiasm with the next
-generation of Carpentry Instructors. Trainers meet regularly. They also have their own dedicated Slack channel and
-email list.
+  prepare prospective Carpentry Instructors to join the community.</p>
 
 Trainers can expect to acquire this <a href="https://github.com/carpentries/commons/blob/master/text-for-trainers.md">skill set</a>.
 <a href="https://docs.carpentries.org/topic_folders/instructor_training/index.html">Find out more about becoming a Trainer</a>.
 
+ <p>This page lists the Trainers who have already consented to be listed on our website. If you are a badged
+  Trainer whose details do not appear here, but you would like to be listed, please 
+  <a href="https://amy.software-carpentry.org/">update your Instructor profile</a> in AMY and agree to make
+  your profile public. <b>Login with GitHub</b> and save your  
+  changes. If you are unable to log in, please 
+  <a href="mailto:team@carpentries.org">email the team</a>. 
 </p>
 
 <div class="container">


### PR DESCRIPTION
adding same info about getting listed as for instructors and maintainers - also cutting out words replicated elsewhere on the site