### PR TITLE
rfc for mission and vision

### DIFF
--- a/_posts/2018/08/2018-08-13-mission-vision-rfc.md
+++ b/_posts/2018/08/2018-08-13-mission-vision-rfc.md
@@ -1,0 +1,33 @@
+---
+layout: page
+authors: ["Karen Cranston", "Ethan White"]
+title: "Request for Comment on Carpentries Mission and Vision"
+teaser: "New mission and vision for the Carpentries"
+date: 2018-08-13
+time: "9:00:00"
+tags: ["Governance", "Feedback", "Mission", "Vision"]
+---
+
+As announced two weeks ago, the Executive Council has been working on developing
+drafts of the mission and vision statements for the new joint
+organization. These drafts are now available and we request your feedback
+through two Requests for Comment and related GitHub issues by Tuesday August 21, 2018.
+
+Requests for Comment (RFCs, also called Requests for Public Comment) are a tool
+used to solicit feedback on planned actions that affect a broad community. These
+RFCs build on those used during the merging of Software and Data Carpentry to
+ensure that these central guiding statements serve all members of our diverse
+community.
+
+Discussion on the two statements will happen separately using GitHub issues:
+
+[Vision Statement](https://github.com/carpentries/executive-council-info/issues/2)
+[Mission Statement](https://github.com/carpentries/executive-council-info/issues/1)
+
+Feedback of any kind is encouraged, including specific ideas for changes,
+concerns about particular language, and support for both the drafted language
+and proposed changes. We want to make sure that the words and ideas in these
+statements are inclusive to all and so actively encourage comments from members
+of underrepresented groups including people of color, members of the LGTBQ
+community, first generation students, and people for whom English is not their
+first language.

--- a/_posts/2018/08/2018-08-13-mission-vision-rfc.md
+++ b/_posts/2018/08/2018-08-13-mission-vision-rfc.md
@@ -11,7 +11,8 @@ tags: ["Governance", "Feedback", "Mission", "Vision"]
 As announced two weeks ago, the Executive Council has been working on developing
 drafts of the mission and vision statements for the new joint
 organization. These drafts are now available and we request your feedback
-through two Requests for Comment and related GitHub issues by Tuesday August 21, 2018.
+through two Requests for Comment and related GitHub issues by midnight (in 
+your time zone) Friday August 31, 2018.
 
 Requests for Comment (RFCs, also called Requests for Public Comment) are a tool
 used to solicit feedback on planned actions that affect a broad community. These


### PR DESCRIPTION
Here is a blog post to go with the two newly-created issues in the Executive Council repo, all asking for feedback on the Mission and Vision statement for the Carpentries. 

I put the feedback deadline as next Tuesday (Aug 21), so that we have feedback in time for the next EC meeting. I can change that if others think it is too short. 