### PR TITLE
Fixes #211: Signup for Clippings on main page

### DIFF
--- a/_includes/mailchimp_short_form.html
+++ b/_includes/mailchimp_short_form.html
@@ -1,0 +1,26 @@
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
+	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<style type="text/css">
+	#mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;}
+	#mergeRow-gdpr {margin-top: 20px;}
+	#mergeRow-gdpr fieldset label {font-weight: normal;}
+	#mc-embedded-subscribe-form .mc_fieldset{border:none;min-height: 0px;padding-bottom:0px;}
+</style>
+<div id="mc_embed_signup">
+<form action="https://carpentries.us14.list-manage.com/subscribe/post?u=46d7513c798c6bd41e5f58f4a&amp;id=50c3e6d6fe" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+	<label for="mce-EMAIL">Subscribe to our Carpentry Clippings Newsletter</label>
+	<input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_46d7513c798c6bd41e5f58f4a_50c3e6d6fe" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+
+<!--End mc_embed_signup-->

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -51,7 +51,7 @@ format: frontpage
     </div><!-- /.row -->
 {% endif %}
 
-
+{% include mailchimp_short_form.html %}
 
 {% comment %}
 *


### PR DESCRIPTION
@weaverbel This adds Newsletter signup to the main page:
![image](https://user-images.githubusercontent.com/119403/44765911-0c5d5280-abab-11e8-884f-ed2b95b755e0.png)
