### PR TITLE
Removed paragraph on mentoring groups and other edits

### DIFF
--- a/pages/inst-dev.md
+++ b/pages/inst-dev.md
@@ -5,35 +5,29 @@ permalink: /inst-dev/
 excerpt: The Instructor Development Committee helps new and established Instructors.
 ---
 
-The Instructor Development Committee (formerly known as the Mentoring Committee) supports Instructors as they progress 
+The Instructor Development Committee (formerly known as the Mentoring Subommittee) supports Instructors as they progress 
 through training, teaching, curriculum development,
 and other community-related activities. They help promote community-building and networking, by 
 providing virtual spaces where instructors from all over the world can share teaching success stories and 
-discuss teaching strategies. For more about our work, see our [onboarding document](http://docs.carpentries.org/topic_folders/mentoring/index.html).
-
-The Committee also organises and oversees the work of Mentoring Groups. These groups support instructors in a variety of ways. 
-Whether you are a new instructor preparing to teach your first workshop, a seasoned instructor hoping to launch workshops in 
-a new community, or an instructor excited about getting involved with lesson development and maintenance, mentoring groups 
-will help you gain the confidence, technical skills, and teaching skills you need to reach your goal.
+discuss teaching strategies. For more about our work, see our [onboarding document](https://docs.carpentries.org/topic_folders/mentoring/discussion_session.html).
 
 _Our Goal:_    
 To support Instructors in our community through a range of activities. 
 
 _Our Approach:_    
-We run regular [instructor discussion sessions](https://pad.carpentries.org/instructor-discussion) where people preparing to teach can ask for advice. People who have recently taught
-can use the sessions to debrief.
-
+We run regular [instructor discussion sessions](https://pad.carpentries.org/instructor-discussion) where people preparing to teach can ask for advice. People who have recently taught can use the sessions to debrief.
 
 _Our Structure:_    
 The Committee has monthly meetings, which are open to new members. Meetings are scheduled, organised, and 
 run through this [etherpad](https://pad.carpentries.org/scf-mentoring).
-For more about committee roles, see the [Handbook](https://docs.carpentries.org/topic_folders/mentoring/mentoring-subcommittee-roles.html). We also organise information about our work though this [GitHub repo](https://github.com/carpentries/mentoring).
+For more about committee roles, see the [Handbook](https://docs.carpentries.org/topic_folders/mentoring/mentoring-subcommittee-roles.html#discussion-session-coordinators). We also organise information about our work though this [GitHub repo](https://github.com/carpentries/mentoring).
 
 _Our Leadership:_    
 There are two co-Chairs. Toby Hodges is one of the current co-Chairs. The other co-Chair position is vacant.
 In addition, a Carpentries staff member is part of the committee as a staff liaison.
 
-_Contacting the Committee:_     
+_Contacting the Committee:_
+[Join us](https://carpentries.topicbox.com/groups/instructor-development) on TopicBox!
 
 
 #### Current Committee Members
@@ -43,4 +37,4 @@ _Contacting the Committee:_
 * Jamie Hadwin
 * Tobin Magle
 * Belinda Weaver
-
+* Sarah Stevens


### PR DESCRIPTION
Changed the onboarding document link to lead to discussion sessions. Removed paragraph mentoring groups because this committee does not manage/oversee the groups. Fixed handbook link to committee roles.

I made several PRs to update the handbook to reflect the name change. The .md files [here](https://github.com/carpentries/handbook/tree/master/topic_folders/mentoring) aren't showing in the handbook for some reason. Once they start showing, we need to fix the links in this page so that they point to the correct instructor development committee pages in the handbook.