### PR TITLE
Internal link rather than external?

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -42,7 +42,7 @@
 
             <div class="row">
                 <div class="medium-9 columns">
-                    <p class="large text-muted">Check out what we do in our newsletter, <em><a href="http://eepurl.com/cfODMH">Carpentry Clippings</a>.</em></p>
+                    <p class="large text-muted">Check out what we do in our newsletter, <em><a href="https://carpentries.org/newsletter/">Carpentry Clippings</a>.</em></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Filing this because I noticed the link to the mailing list in the list-manage.com CC signup page points to http://lists.software-carpentry.org/listinfo/discuss, which doesn't exist anymore.