### PR TITLE
Create 2018-12-03-instructor-training-curriculum-updates.md

### DIFF
--- a/_posts/2018/12/2018-12-03-instructor-training-curriculum-updates.md
+++ b/_posts/2018/12/2018-12-03-instructor-training-curriculum-updates.md
@@ -1,0 +1,95 @@
+---
+layout: page
+authors: ["Karen Word", "Christina Koch", "Rayna Harris"]
+teaser: "What’s new in the Instructor Training curriculum?"
+title: "Instructor Training Curriculum Updates"
+date: 2018-12-03
+time: "09:00:00"
+tags: ["Instructor Training", "Curriculum"]
+---
+
+# Instructor Training Curriculum Updates
+The [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/) is a centerpiece among the Carpentries workshops. It is constantly in use as we bring new Instructors on board, and our engaged Instructor Trainer community brings a steady stream of new ideas for its improvement. This makes for a fun community, interesting discussions... and a lengthy to-do list! In the month of October we organized a "push" on the Instructor Training curriculum, in which we made good progress on backlogged issues, organization, and usability for new Instructor Trainers. This is not a full "release" -- we're about halfway to where we'd like to be for our next published update -- but we are pleased with what we've accomplished and hope you will be, too. We are particularly grateful to the community of Instructor Trainers whose feedback and contributions have both inspired this work and helped to complete it!
+
+## What's new?
+Most of the changes with this update involved re-organizing and prioritizing content that was already present in the curriculum. There are, however, some things that are entirely new and others that re-introduce content from previous versions of the curriculum.
+
+* **Library Carpentry** is a lesson program now! Its history and characteristics have been added to [The Carpentries: How We Operate](https://carpentries.github.io/instructor-training/21-carpentries/index.html)
+* Some old friends are back! **Bloom's Taxonomy and Reverse Curriculum Design** were removed in an earlier update, when we stepped back our focus on curriculum design. Here, we bring them to bear on the process of [preparing to teach an existing workshop](https://carpentries.github.io/instructor-training/15-lesson-study/index.html).
+* We have some terrific **[new](https://carpentries.github.io/instructor-training/02-practice-learning/index.html) [figures](https://carpentries.github.io/instructor-training/21-carpentries/index.html), [handouts](https://carpentries.github.io/instructor-training/24-practices/index.html) and terminology updates** (e.g. live coding -> *participatory* live coding)
+* **New episodes** highlight existing and new content on [classroom management](https://carpentries.github.io/instructor-training/18-management/index.html) and [instructor checkout](https://carpentries.github.io/instructor-training/20-checkout/index.html).
+
+## What's changed?
+* **Episode titles!** The titles of all episodes have been shortened to make them easier to work with. However, the structure provided by the previous 2-part titles has been preserved in the metadata for each page, so they may return in a more usable format in future updates.
+* **"Optional" exercises!** Some exercises are now tagged as "optional." This should help Trainers -- especially new Trainers -- manage time effectively without cutting core content. It also leaves Trainers with flexibility to decide which activities work best for them and their workshop.
+* **Day 2!** The second day of the workshop has been reorganized to improve flow and timing.
+    * The former "Lesson Study" episode has been overhauled and renamed to focus more specifically on [preparing to teach](https://carpentries.github.io/instructor-training/15-lesson-study/index.html).
+    * The [Introductions episode](https://carpentries.github.io/instructor-training/23-introductions/index.html) has been shortened to make room for commonly observed time shortages in other lessons. Much of this time was added to allow more relaxed exploration of GitHub during the [Workshop Operations episode](https://carpentries.github.io/instructor-training/21-carpentries/index.html).
+    * Live Coding practice sessions are now interspersed with episodes relying on more direct instruction. This should improve pacing as well as providing food for thought to carry into the second round.
+    * Introductory Q&A has been re-homed to keep the morning moving and situate discussion in the [appropriate episode](https://carpentries.github.io/instructor-training/21-carpentries/index.html).
+* **[Instructor notes](https://carpentries.github.io/instructor-training/guide/index.html)!** Most of the content that was previously housed on this page is now contained in the [Carpentries Handbook](https://docs.carpentries.org/topic_folders/instructor_training/index.html#for-trainers). Some of that text remains (redundantly) because it is specifically useful when preparing to teach a workshop. In addition, we have created room for subjective comments and suggestions from Trainers on how to use the lessons. This is intended to take some of the pitfalls and suggestions often housed in Issues and make them more usable until such a time as they can be addressed through curriculum updates. It also provides a home for more subjective comments or variant suggestions that don't necessarily need to result in changes. 
+* There were also many **small but important adjustments** to awkward or inaccurate text that helped improve the overall quality of the lesson. 
+* Did we forget to mention one of your favorite updates? Please add it in the comments!
+
+## It takes a village!
+We'd like to take a moment to thank EVERYONE who has contributed to this curriculum since the last update was released! The following is a list of GitHub Users who have contributed, in order of number of contributions: 
+
+- Karen Word (Maintainer)
+- Christina Koch (Maintainer)
+- maneesha sane
+- François Michonneau
+- Rayna Harris
+- Lex Nederbragt
+- Belinda Weaver
+- amyehodge
+- Raniere Silva
+- Murray Cadzow
+- Maxim Belkin
+- Ariel Rokem
+- Ian Lee
+- Remi Rampin
+- Toby Hodges
+- Aleksandra Nenadic
+- Kari L. Jordan
+- Paula Andrea Martinez
+- sheraaron
+- Katrin Leinweber
+- Nicolas Palopoli
+- Noah Spies
+- Alexander Konovalov
+- Allison Weber
+- Anelda van der Walt
+- LejoFlores
+- Mik Black
+- Neil Kindlon
+- Stéphane Guillou
+- Tracy Teal
+- Yo Yehudi
+- Alistair Walsh
+- Callin
+- Chris Erdmann
+- Colin Morris
+- Dan Allan
+- DanielBrett
+- Darya Vanichkina
+- davidbenncsiro
+- Eric Jankowski
+- Gerard Capes
+- Greg Wilson
+- Jason M. Gates
+- John Bradley
+- Jonah Duckles
+- Laurence
+- Marie-Helene Burle
+- naught101
+- Nicholas Tierney
+- Petraea
+- Sarah Brown
+- satya-vinay
+- Tiago M. D. Pereira
+- Tyler Smith
+- Erin Becker
+- jsta
+- Stephan Druskat
+- Trevor Keller
+- trk


### PR DESCRIPTION
Add blog post about new Instructor Training curriculum updates. Note to @karenword - I removed two duplicate names in the list of contributors (Belinda Weaver and Sarah Brown), leaving them at the higher of the two positions in the list.