### PR TITLE
Mention Jekyll in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
+# Jekyll site settings.
+# Jekyll is a Ruby tool for building static sites.
+# Github Pages does all the hard work of building the Jekyll site. Yay!
+# Custom CNAME settings in this repository make carpentries.org redirect
+# to the Github Pages page.
+# 
 # ASCII-Font › http://patorjk.com/software/taag/#p=display&f=Slant&t=Phlow
 #
 #      _____ _ __          _____      __  __  _


### PR DESCRIPTION
It's a good idea to mention explicitly what technologies are using config.yml, since "config" is pretty generic and Jekyll isn't mentioned anywhere in the file.