### PR TITLE
Proposing a Community Discussions Page

### DIFF
--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -1,0 +1,36 @@
+## Community Discussions 
+
+Community Discussions are designed for everyone in The Carpentries community interested in learning, educating and advocating for teaching foundational coding and data science skills globally. Discussion topics range anywhere from teaching workshops and developing curricula to building local communities and assessing the impact of our workshops globally.
+
+Community Discussions are free and open to anyone. They provide opportunities to connect with The Carpentries community. There are three types of Community Discussion:
+
+1. __Pre- and Post-Workshop Discussions__ These discussions are designed for those getting ready to teach or having recently taught to come discuss their workshop with the community. They occur twice per week.
+
+2. __Themed Discussion Sessions__ These discussions are centered around a particular topic ranging anywhere from teaching your first workshop to community building strategies. They occur once per month.
+
+3.	__Carpentries Conversations__ These Conversations are hosted by one of our Committees or Task Forces to provide the community with the opportunity to learn about and discuss new developments and programs in our organisation. They occur once per month.
+
+Attend any Community Discussion by signing-up on the [community-discussions Etherpad](https://pad.carpentries.org/community-discussions).
+
+Interested in hosting a Community Discussion? Complete our [call for community discussion facilitators form](https://goo.gl/forms/STUEN15QWrlPlhm92)!
+
+## Next Call
+What's New with Library Carpentry            
+Thursday February 28    
+15:00 UTC      
+[Click here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Themed+Discussion+Session%3A+What%27s+New+with+Library+Carpentry&iso=20190228T15&p1=1440&ah=1) for your time zone.   
+[Sign-up](https://pad.carpentries.org/community-discussions)
+
+Thursday February 28    
+23:00 UTC     
+[Click here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Themed+Discussion+Session%3A+What%27s+New+with+Library+Carpentry&iso=20190228T23&p1=1440&ah=1) for your time zone.    
+[Sign-up](https://pad.carpentries.org/community-discussions)
+
+## Past Calls
+* [What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
+* Delivering Exercises to Learners with Load Magic - Sarah Brown (2018-11-7)      
+* My first workshop: Navigating unpredictable learning environments - Kari L. Jordan (2018-04-24)      
+* Best use of the etherpad in your workshop - Toby Hodges (2018-04-20)      
+* Building a Local Carpentries Community: instructors, Helpers, Learners and Advocates - Jamie Hadwin (2018-04-18)      
+* Interpreting and acting on feedback and pre-/post-workshop assessments - Toby Hodges (2018-04-10)      
+* How to run a workshop with no money - Anelda van der Walt (2018-03-23)    

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -29,7 +29,7 @@ Themed Discussion Session: The Carpentries in Australia
  
 ## Past Calls
 * #CarpentriesConversation: CarpentryCon 2020 - CarpentryCon Task Force (2019-03-20)
-* The Carpentries in New Zealand: [Notes](https://docs.google.com/document/d/1W1DhgBoOSdPCa17SWcALiP1Zxg4VNAj_KHe2-trKZpk/edit?ts=5c92adb2#heading=h.d7c6siica7vj) - Megan Guidry (2019-03-11)
+* The Carpentries in New Zealand: [Notes](https://docs.google.com/document/d/1W1DhgBoOSdPCa17SWcALiP1Zxg4VNAj_KHe2-trKZpk/edit?ts=5c92adb2#heading=h.d7c6siica7vj), [Slide deck](https://docs.google.com/presentation/d/1XauUAIBS4bJQcxLaguKz7FUbcbyh1EuQxzCZ1Egop4k/edit?ts=5c92acfc#slide=id.g3b8317a2f2_1_29) - Megan Guidry (2019-03-11)
 * What's New with Library Carpentry: [Video](https://youtu.be/lR0MbC95lgg), [Slide deck](https://docs.google.com/presentation/d/1bseEc15qeIflOEHm_7-Z2kd2EHRTllyMMugGd-m68D8/edit#slide=id.p) - Chris Erdmann (2019-02-28)
 * [#CarpentriesConversation: What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
 * [Delivering Exercises to Learners with Load Magic](https://carpentries.org/blog/2018/11/delivering-exercises/) - Sarah Brown (2018-11-7)      

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -22,12 +22,10 @@ Attend any Community Discussion by signing-up on the [community-discussions Ethe
 Interested in hosting a Community Discussion? Complete our [call for community discussion facilitators form](https://goo.gl/forms/STUEN15QWrlPlhm92)!
 
 ## Next Call
-Themed Discussion Session: The Carpentries in Australia    
-12:00 noon AEDT      
-[Click here for your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=The+Carpentries+Themed+Discussion+Session%3A+The+Carpentries+in+Australia&iso=20190402T01&ah=1)  
-[Sign-up](https://pad.carpentries.org/community-discussions)    
+   
  
 ## Past Calls
+* The Carpentries in Australia - Damien Irving (2019-04-01)
 * #CarpentriesConversation: CarpentryCon 2020 - CarpentryCon Task Force (2019-03-20)
 * The Carpentries in New Zealand: [Notes](https://docs.google.com/document/d/1W1DhgBoOSdPCa17SWcALiP1Zxg4VNAj_KHe2-trKZpk/edit?ts=5c92adb2#heading=h.d7c6siica7vj), [Slide deck](https://docs.google.com/presentation/d/1XauUAIBS4bJQcxLaguKz7FUbcbyh1EuQxzCZ1Egop4k/edit?ts=5c92acfc#slide=id.g3b8317a2f2_1_29) - Megan Guidry (2019-03-11)
 * What's New with Library Carpentry: [Video](https://youtu.be/lR0MbC95lgg), [Slide deck](https://docs.google.com/presentation/d/1bseEc15qeIflOEHm_7-Z2kd2EHRTllyMMugGd-m68D8/edit#slide=id.p) - Chris Erdmann (2019-02-28)

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -28,7 +28,7 @@ Thursday February 28
 
 ## Past Calls
 * [What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
-* Delivering Exercises to Learners with Load Magic - Sarah Brown (2018-11-7)      
+* [Delivering Exercises to Learners with Load Magic](https://carpentries.org/blog/2018/11/delivering-exercises/) - Sarah Brown (2018-11-7)      
 * My first workshop: Navigating unpredictable learning environments - Kari L. Jordan (2018-04-24)      
 * Best use of the etherpad in your workshop - Toby Hodges (2018-04-20)      
 * Building a Local Carpentries Community: instructors, Helpers, Learners and Advocates - Jamie Hadwin (2018-04-18)      

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -29,7 +29,7 @@ Themed Discussion Session: The Carpentries in Australia
  
 ## Past Calls
 * #CarpentriesConversation: CarpentryCon 2020 - CarpentryCon Task Force (2019-03-20)
-* The Carpentries in New Zealand - Megan Guidry (2019-03-11)
+* The Carpentries in New Zealand: [Notes](https://docs.google.com/document/d/1W1DhgBoOSdPCa17SWcALiP1Zxg4VNAj_KHe2-trKZpk/edit?ts=5c92adb2#heading=h.d7c6siica7vj) - Megan Guidry (2019-03-11)
 * What's New with Library Carpentry: [Video](https://youtu.be/lR0MbC95lgg), [Slide deck](https://docs.google.com/presentation/d/1bseEc15qeIflOEHm_7-Z2kd2EHRTllyMMugGd-m68D8/edit#slide=id.p) - Chris Erdmann (2019-02-28)
 * [#CarpentriesConversation: What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
 * [Delivering Exercises to Learners with Load Magic](https://carpentries.org/blog/2018/11/delivering-exercises/) - Sarah Brown (2018-11-7)      

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -1,3 +1,10 @@
+---
+layout: page-fullwidth
+title: "Community Discussions"
+permalink: /community_discussions/
+excerpt: Learn how to join our various types of Community Discussions
+---
+
 ## Community Discussions 
 
 Community Discussions are designed for everyone in The Carpentries community interested in learning, educating and advocating for teaching foundational coding and data science skills globally. Discussion topics range anywhere from teaching workshops and developing curricula to building local communities and assessing the impact of our workshops globally.

--- a/pages/community-discussions.md
+++ b/pages/community-discussions.md
@@ -22,19 +22,16 @@ Attend any Community Discussion by signing-up on the [community-discussions Ethe
 Interested in hosting a Community Discussion? Complete our [call for community discussion facilitators form](https://goo.gl/forms/STUEN15QWrlPlhm92)!
 
 ## Next Call
-What's New with Library Carpentry            
-Thursday February 28    
-15:00 UTC      
-[Click here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Themed+Discussion+Session%3A+What%27s+New+with+Library+Carpentry&iso=20190228T15&p1=1440&ah=1) for your time zone.   
-[Sign-up](https://pad.carpentries.org/community-discussions)
-
-Thursday February 28    
-23:00 UTC     
-[Click here](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Themed+Discussion+Session%3A+What%27s+New+with+Library+Carpentry&iso=20190228T23&p1=1440&ah=1) for your time zone.    
-[Sign-up](https://pad.carpentries.org/community-discussions)
-
+Themed Discussion Session: The Carpentries in Australia    
+12:00 noon AEDT      
+[Click here for your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=The+Carpentries+Themed+Discussion+Session%3A+The+Carpentries+in+Australia&iso=20190402T01&ah=1)  
+[Sign-up](https://pad.carpentries.org/community-discussions)    
+ 
 ## Past Calls
-* [What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
+* #CarpentriesConversation: CarpentryCon 2020 - CarpentryCon Task Force (2019-03-20)
+* The Carpentries in New Zealand - Megan Guidry (2019-03-11)
+* What's New with Library Carpentry: [Video](https://youtu.be/lR0MbC95lgg), [Slide deck](https://docs.google.com/presentation/d/1bseEc15qeIflOEHm_7-Z2kd2EHRTllyMMugGd-m68D8/edit#slide=id.p) - Chris Erdmann (2019-02-28)
+* [#CarpentriesConversation: What Happens During a Code of Conduct Investigation?](https://docs.google.com/presentation/d/10eLnpfiIjkyZUd9yYlHJAqP_HeQcLJ07L_XAKRzVKiE/edit#slide=id.g3b8317a2f2_1_66) - Karin Lagesen (2019-01-31)    
 * [Delivering Exercises to Learners with Load Magic](https://carpentries.org/blog/2018/11/delivering-exercises/) - Sarah Brown (2018-11-7)      
 * My first workshop: Navigating unpredictable learning environments - Kari L. Jordan (2018-04-24)      
 * Best use of the etherpad in your workshop - Toby Hodges (2018-04-20)      

--- a/pages/community.md
+++ b/pages/community.md
@@ -216,7 +216,9 @@ going on throughout our community.
 
 <span style="background-color: #5ABEB3"> Highlighted in green</span> are key events whose delivery is the responsibility of [The Carpentries team](/team).
 
-<div id='calendar' markdown="0">Community Calendar goes here</div>s
+<span style="background-color: #333333; color:white"> Highlighted in grey</span> are various community discussions that you are welcome to join. 
+
+<div id='calendar' markdown="0">Community Calendar goes here</div>
 
 <hr> 
 
@@ -393,14 +395,12 @@ going on throughout our community.
 </table>
 --->
 
-
-
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script> 
 
 <script type="text/javascript"> 
 var timezone = jstz.determine();
-var frame_setup = '<iframe src="https://calendar.google.com/calendar/b/1/embed?title=The%20Carpentries%20Community%20Calendar%20&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&amp;color=%235229A3&amp;src=qhpv7vf5pqlrecgt7prvume0mckegv1s%40import.calendar.google.com&amp;color=%231B887A&amp;ctz=';
+var frame_setup = '<iframe src="https://calendar.google.com/calendar/b/1/embed?title=The%20Carpentries%20Community%20Calendar%20&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&amp;color=%23333333&amp;src=qhpv7vf5pqlrecgt7prvume0mckegv1s%40import.calendar.google.com&amp;color=%231B887A&amp;ctz=';
 var frame_close = '" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
 var full_link = frame_setup + timezone.name() + frame_close;
 document.getElementById('calendar').innerHTML = full_link;

--- a/pages/community.md
+++ b/pages/community.md
@@ -212,9 +212,11 @@ A global CarpentryCon will be held every two years, with locally organised Carpe
 ### Community events
 There are many opportunities to join community meetings, subcommittees
 and debriefing sessions. Find links to them on this <a href="http://pad.software-carpentry.org/pad-of-pads">Etherpad</a>, and subscribe to the calendar below to watch all that is
-going on throughout our community.
+going on throughout our community. 
 
-<div id='calendar' markdown="0">Community Calendar goes here</div>
+<span style="background-color: #5ABEB3"> Highlighted in green</span> are key events whose delivery is the responsibility of [The Carpentries team](/team).
+
+<div id='calendar' markdown="0">Community Calendar goes here</div>s
 
 <hr> 
 


### PR DESCRIPTION
Per @ErinBecker "I think it would be nice to have. Maybe it doesn’t need to have it’s own menu pull down item, but could be linked to from the “connect” page?"

The purpose of this page is to provide archived and upcoming community discussions. I'd like to format it similar to https://ropensci.org/commcalls/