### PR TITLE
Center widget + change mailchimp signup form font

### DIFF
--- a/_includes/_frontpage-widget.html
+++ b/_includes/_frontpage-widget.html
@@ -1,4 +1,4 @@
-<div class="medium-4 columns frontpage-widget">
+<div class="medium-4 columns frontpage-widget text-center">
 	{% capture widget_url %}{% if include.widget.url contains 'http' %}{{ include.widget.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ include.widget.url }}{% endif %}{% endcapture %}
 	{% if include.widget.video %}
 		{{ include.widget.video }}
@@ -15,10 +15,10 @@
 		</a>
 	{% endif %}
 	{% if include.widget.icon %}
-	<div style="text-align:center;"><i class="{{ include.widget.icon }} fa-7x" style="color:#94ACD9;"></i></div>
+	<div><i class="{{ include.widget.icon }} fa-7x" style="color:#94ACD9;"></i></div>
 	{% endif %}	
 
-	<h2 class="font-size-h3 t10" style="text-align:center;">{{ include.widget.title }}</h2>
+	<h2 class="font-size-h3 t10">{{ include.widget.title }}</h2>
 	<p>{{ include.widget.text }}</p>
 	<p><a class="button tiny radius" href="{% if include.widget.url contains 'http' %}{{ include.widget.url }}{% else %}{{ site.url }}{{ site.baseurl }}{{ include.widget.url }}{% endif %}">{{ site.data.language.more }}</a></p>
 </div>

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -102,7 +102,7 @@
 	<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
 
         <!-- mailchimp -->
-        <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+        <link href="https://cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
         <style type="text/css">
           #mc_embed_signup{background:#fff; clear:left; font:14px; width:100%;}
           /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -104,7 +104,7 @@
         <!-- mailchimp -->
         <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
         <style type="text/css">
-          #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
+          #mc_embed_signup{background:#fff; clear:left; font:14px; width:100%;}
           /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
           We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
         </style>


### PR DESCRIPTION
I think the text and buttons in the widgets on the front page look better when center-aligned.

![screenshot from 2019-03-05 09-26-20](https://user-images.githubusercontent.com/5502922/53791189-1a5ca900-3f29-11e9-8530-bdd3f66b41b4.png)


I also changed the font above the newsletter sign up to match the rest of the site