### PR TITLE
Adding person anchors to link directly to people's profiles

### DIFF
--- a/assets/css/extras.css
+++ b/assets/css/extras.css
@@ -48,7 +48,10 @@ ul, menu, dir {
 }
 
 
-
+.anchor-offset {
+   padding-top: 50px;
+   margin-top: -50px;
+}
 
 .team-member {
     margin-bottom: 50px;

--- a/pages/instructors.html
+++ b/pages/instructors.html
@@ -32,7 +32,7 @@ permalink: /instructors/
 
 
 <div class="medium-3 columns">
-<div class="team-member">
+    <div id="{{ person.github }}" class="anchor-offset team-member">
   <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
   <h3>{{ person.person_name }}</h3>
   <ul class="list-inline social-buttons">

--- a/pages/maintainers.html
+++ b/pages/maintainers.html
@@ -45,7 +45,7 @@ Maintainers can expect to acquire this <a href="https://github.com/carpentries/c
 {% endif %}
 
 <div class="medium-3 columns">
-<div class="team-member">
+    <div id="{{ person.github }}" class="anchor-offset team-member">
   <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
   <h3>{{ person.person_name }}</h3>
   <ul class="list-inline social-buttons">

--- a/pages/mentors.html
+++ b/pages/mentors.html
@@ -41,8 +41,8 @@ permalink: /mentors/
 
 
 <div class="medium-3 columns">
-<div class="team-member">
-  <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
+  <div id="{{ person.github }}" class="anchor-offset team-member">
+    <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
   <h3>{{ person.person_name }}</h3>
   <ul class="list-inline social-buttons">
       {% if person.twitter %}<li> <a href="https://twitter.com/{{ person.twitter }}"> <i class="fab fa-twitter"></i> </a> </li> {% endif %}

--- a/pages/trainers.html
+++ b/pages/trainers.html
@@ -52,8 +52,8 @@ Trainers can expect to acquire this <a href="https://github.com/carpentries/comm
 {% endif %}
 
 <div class="medium-3 columns">
-<div class="team-member">
-  <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
+  <div id="{{ person.github }}" class="anchor-offset team-member">
+    <img data-src="https://avatars.githubusercontent.com/{{ person.github }}" width=128 height=128 class="img-responsive img-circle lazyload" alt="GitHub profile photo of {{person.person_name}}">
   <h3>{{ person.person_name }}</h3>
   <ul class="list-inline social-buttons">
       {% if person.twitter %}<li> <a href="https://twitter.com/{{ person.twitter }}"> <i class="fab fa-twitter"></i> </a> </li> {% endif %}


### PR DESCRIPTION
Addressing https://github.com/swcarpentry/website/issues/1071 by adding anchors to people's carpentries profiles with their GitHub username. Example: My profile will be linkable at `https://carpentries.org/instructors/#jduckles` once this is merged.