### PR TITLE
CDH Handbook blog post - MERGE ON APRIL 3rd

### DIFF
--- a/_posts/2019/04/2019-04-03-curriculum-development-handbook.md
+++ b/_posts/2019/04/2019-04-03-curriculum-development-handbook.md
@@ -1,0 +1,38 @@
+---
+layout: page
+authors: ["Erin Becker", "François Michonneau"]
+teaser: "A guide for creating Carpentries-style lessons."
+title: "Announcing The Carpentries Curriculum Development Handbook"
+date: 2019-04-03
+time: "09:00:00"
+tags: ["Curriculum"]
+---
+
+A key value of community is the horizontal transmission of culture - sharing mistakes we’ve made and lessons we’ve learned so that things are easier for the next person. In our [Instructor Training](https://carpentries.github.io/instructor-training/) program, we prepare new instructors to teach existing content using evidence-based teaching methods. The spirit of Carpentries lessons, however, doesn’t lie in reproducing the script faithfully and teaching the content “as is”. Every time our lessons are taught, they’re a little bit different, as Instructors try things out, learn, and (hopefully) contribute back to the lessons so that others can benefit from their experiences. Because of the innovation of our Instructors, and the value our community places on iteration and collaborativity, The Carpentries’ lessons get stronger every time they are taught. 
+
+Many people are eager to apply The Carpentries pedagogical model to their teaching in other contexts and to develop new lessons that take advantage of The Carpentries’ collective wisdom and tooling around lesson design. As this community grows into new domains, we see more and more frequent proposals around designing new lessons, including in digital humanities, astronomy, social sciences, library sciences, imaging, economics, chemistry, statistics, high performance computing, meteorology, and neuroimaging. In contrast to our teaching principles, which are encoded in our Instructor Training curriculum, our community values around lesson development and design haven’t had a cultural locus - a place where community members can come together, test things out, and iterate within a framework of evidence-based curricular design. 
+
+Bits and pieces of our community’s collective wisdom around lesson creation have historically been scattered throughout various other resources, never having a home of their own. With the generous support of the [Alfred P. Sloan Foundation](https://sloan.org/), The Carpentries staff (Francois and Erin) have been able to gather these resources and construct them into a coherent framework to guide future community lesson development. Thus is born a first draft of The Carpentries [Curriculum Development Handbook](https://cdh.carpentries.org/)!
+
+Although, as “first draft” suggests, there is much content to be added, we are excited to share this resource with the community. We know that the culturally valuable testing, iteration, and strengthening of this content can’t start until the community knows it exists and is using it. This early development version focuses on the early stages in curriculum development, with the goal of helping community members who are just starting to create their lesson to start out on a clear path following evidence-based pedagogical design principles. This content walks lesson developers from initial lesson conception through to fully formed materials that can be used for a pilot workshop. 
+
+A brief overview of the Handbook’s current content can be found below:  
+
+- [Chapter 1: Conceptual elements](https://cdh.carpentries.org/conceptual-elements.html) - an overview of The Carpentries approach to curriculum development including the stages of development (extended in chapters 2-5) and the components of a Carpentries curriculum.   
+
+- [Chapter 2: Deciding what to teach](https://cdh.carpentries.org/deciding-what-to-teach.html) - a guide to the process of defining your target audience and establishing a "skill set" that can be used for the rest of the development process.  
+
+- [Chapter 3: Designing Challenges](https://cdh.carpentries.org/designing-challenges.html) - covers the practicalities of the second stage of the curriculum development process, creating exercises. Starting with a guide to how to select a dataset, this chapter introduces several different types of exercises and discusses when each is appropriate. 
+
+- [Chapter 4: Developing content](https://cdh.carpentries.org/developing-content.html) - builds on Chapters 2 and 3. Walks lesson authors through the process of creating code chunks, narrative sections, and other supporting elements of the curriculum.
+
+- [Chapter 5: Community development](https://cdh.carpentries.org/community-development.html) - lays out the framework for community support of a lesson, including the roles played by various community segments, training needed for those roles, and when each role should be filled during the lesson development process.
+
+- [Chapter 6: Technological introductions](https://cdh.carpentries.org/technological-introductions.html) - goes into some detail about how our templates work and how we structure our lessons on GitHub. 
+
+A later version of this Curriculum Development Handbook will also include resources for iterating on and improving the first lesson draft, and guidance on creating a community around the lesson. This will include materials for recruiting and training lesson maintainers, running pilot workshops, and building a broad community of instructors to teach the lessons. 
+
+In the long term, we hope to be able to convert this Handbook into a full curriculum for teaching lesson design. This training would be offered independently of our Instructor Training program and would prepare individuals to develop a new Carpentries-style lesson, for inclusion in our official curriculum offerings or for informal use within and outside of The Carpentries community. Francois Michonneau will be piloting a short version of this Curriculum Development workshop at [CarpentryConnect Manchester](https://software.ac.uk/ccmcr19) in June.  
+
+If you are currently writing your own Carpentries-style curriculum, think you might in the future, or are just curious about how it all works, please visit the draft [Curriculum Development Handbook](https://cdh.carpentries.org) and leave comments, suggestions, or edits through the [associated GitHub repository](https://github.com/carpentries/curriculum-development). I’m personally very excited to see the community start to use and improve on these materials, so that our community can begin to more systematically develop a shared approach to lesson creation that complements our community’s shared vision of instruction.
+


### PR DESCRIPTION
Add blog post for Curriculum Development handbook first launch