### PR TITLE
adding the Mission to the About page

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -4,6 +4,8 @@ title: "About Us"
 permalink: /about/
 ---
 
+**Mission:** The Carpentries builds global capacity in essential data and computational skills for conducting efficient, open, and reproducible research. We train and foster an active, inclusive, diverse community of learners and instructors that promotes and models the importance of software and data in research. We collaboratively develop openly-available lessons and deliver these lessons using evidence-based teaching practices. We focus on people conducting and supporting research.
+
 Here you will find a range of useful information about our work. For more information on all things Carpentries, see [The Carpentries Handbook](https://docs.carpentries.org/) and for a summary of our impact and operations, see our [Annual Report](https://carpentries.org/files/assessment/TheCarpentries2018AnnualReport.pdf).
 
 * [About The Carpentries](#about-the-carpentries)   


### PR DESCRIPTION
Adding the Mission statement from the [approved](https://github.com/carpentries/executive-council-info/issues/7) [Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html) to the About page.