### PR TITLE
Added blog post to release CoCc mandate recommendations

### DIFF
--- a/_posts/2019/09/2019-09-19-cocc-taskforce-summary-recommendations.md
+++ b/_posts/2019/09/2019-09-19-cocc-taskforce-summary-recommendations.md
@@ -1,0 +1,34 @@
+---
+layout: page
+authors: ["Kari L. Jordan", “Christopher Felker”]
+teaser: "The Carpentries should be a leader in ensuring that our community is a safe and welcoming space."
+title: "Code of Conduct Mandate Task Force Releases Recommendations"
+date: 2019-09-19
+time: "09:00:00"
+tags: ["Code of Conduct"]
+---
+
+The global Carpentries community is growing. Community members are running more workshops, engaging with each other and sharing our content broadly, and speaking on behalf of The Carpentries at various meetings and on social media. With our growth comes an added awareness of the different ways our community engages with each other inside and outside our spaces and in the broader open scholarship/open data ecosystem. As such, potential conflicts or breaches of our Code of Conduct can arise. Currently, some incidents we may want to be aware of and respond to are outside our Code of Conduct Committee’s (CoCc) formal guidelines and processes. As a vanguard organisation with a digital and technological purpose, the organisation needs to respond to these incidents transparently, respecting multiple countries traditions and practices, and legal considerations. To address this, a [Code of Conduct Committee Mandate Task Force](https://carpentries.org/blog/2019/07/incidents-outside-cocc-mandate/) was convened to make _recommendations_ to help respond to incidents that happen outside the existing mandate of the Carpentries Code of Conduct Committee.  
+
+This task force met four times during August and September 2019 with work taking place asynchronously between meetings. Outcomes from this task force were tracked publicly in the [task-forces repository](https://github.com/carpentries/task-forces/projects/1) under the Carpentries GitHub organisation. The task force was formed of a combination of staff and community members. The members of the task force were:
+
+- Samantha Ahern - University College London, Code of Conduct committee member and certified Carpentries Instructor
+- Karen Cranston - Executive Council Member 
+- Christopher Felker - University of California - San Diego, certified Carpentries Instructor with legal expertise
+- Kari L. Jordan - Carpentries staff, staff liaison for Code of Conduct committee
+- Luca Di Stasio - Luleå University of Technology and Université de Lorraine, certified Carpentries Instructor with expertise in cross-cultural communication 
+
+The task force [opened a form](https://carpentries.org/blog/2019/08/collecting-incidents-community/) from 13-31 August 2019 where community members safely provided anonymous feedback about uncomfortable situations experienced or witnessed that occurred within and outside Carpentries spaces (in-person or online) involving Carpentries community members. We wanted to know about the incidents, the experiences of individuals who were directly affected, and how the incidents were handled, including whether or not these incidents were shared with the CoCc. Twelve responses were received during this collection period. Additionally, we opened several [GitHub issues](https://github.com/carpentries/task-forces/issues?q=is%3Aissue+is%3Aclosed) about  relevant codes of conduct and practices of similar organisations to inform our recommendations. The task force was particularly impressed by similar approaches put forth by R-Ladies who are challenging the perceived and actual models for sharing information inside inclusive communities. From this community feedback and the information we collected, we present our recommendations.
+
+## Summary of Recommendations
+The task force has determined that neither the Carpentries Staff, Code of Conduct Committee, nor the Executive Council is _exclusively_ responsible for monitoring and/or _proactively responding_ to dialogue in Carpentries spaces (in-person or online), or non-Carpentries spaces where Carpentries community members are active. Our recommendation is for the Code of Conduct Committee, Regional Coordinators, and Instructor Trainers to encourage and empower community members to share any incidents or concerns to an ombudsperson or the CoCc. Additionally, we recommend making the button to report a CoC violation more prominent on the Carpentries website.
+
+The task force agrees that The Carpentries should be in the vanguard in developing approaches for ensuring that open scholarship/open data communities are safe and welcoming spaces. As a consequence, the Carpentries might need to update policies to reflect this more social and global understanding of how people are treated in physical and digital spaces. Our recommendations are in favour of expanding the scope of incidents that justify a Carpentries response, and in encouraging community members to: share incidents, even if minor or if they happen outside our spaces; and share unwelcome or inappropriate conduct that happens to anyone that is adjacent to our activities (for example, hotel employees, persons expressing their free speech rights or students). Our recommendations do not aim to expand the scope of the Code of Conduct Committee. We recommend socialising the discussion, investigation and outcome of incidents that come to the attention of the Carpentries leadership. In practice, there may be a net increase in community members who have responsibility for monitoring, reporting, and acting on incidents.
+
+The community is welcome to read the [full report with detailed recommendations](https://github.com/carpentries/task-forces/tree/master/2019/09/2019-09-19-cocc-taskforce-summary-recommendations.md). 
+
+We want to sincerely thank everyone who has been involved in this discussion and process. 
+
+## Future Work
+We recognise that the implementation of our recommendations will require community engagement on all levels (staff, partner, local leaders/champions) and pathways to develop local leadership. Our plan is to develop a roadmap for evaluating and implementing the recommendations from the task force. This roadmap will be spearheaded by Kari L. Jordan (Senior Director of Equity and Assessment for The Carpentries). Community members are welcome to [get in touch](mailto:kariljordan@carpentries.org) to share your thoughts on this work. 
+


### PR DESCRIPTION
This blog post can be merged by @tracykteal once the [PR on the task forces repo](https://github.com/carpentries/task-forces/pull/7) is merged.