### PR TITLE
exclude people with no country (empty string, not null)

### DIFF
--- a/_includes/community_profiles.md
+++ b/_includes/community_profiles.md
@@ -22,9 +22,9 @@
       {% if person.orcid %}<li> <a href="https://orcid.org/{{ person.orcid }}"> <i class="fab fa-orcid"></i> </a> </li> {% endif %}
       {% if person.url and person.url != "" %}<li> <a href="{{ person.url }}"> <i class="fas fa-link"></i> </a> </li> {% endif %}
   </ul>
-  {% if person.country %}
+  {% unless person.country == "" %}
   <img width="64" src="/files/flags/{{ person.country | downcase }}.svg"/>
-  {% endif %}
+  {% endunless %}
 </div>
 </div>
 


### PR DESCRIPTION
Code originally evaluated just for `if person.country`  but if there is no country, it is stored as an empty string, not as `null`.  So this evaluates for an empty string instead of null.