### PR TITLE
Fixing some default attribution and rss stuff for the tagathon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ description: "The Carpentries is a fiscally sponsored project of <a href='http:/
 
 # Main author of the website
 # See > authors.yml
-author: weaverbel
+author: admin
 
 # This URL is the main address for absolute links. Don't include a slash at the end.
 #
@@ -136,7 +136,7 @@ defaults:
       show_meta: false 	# Hide metadata for all pages
       # sidebar:    		# Possible values › left, right › by default there will be no sidebar
       comments: false
-      author: weaverbel     # Default author for pages
+      author: admin     # Default author for pages
   -
     scope:
       path: ""
@@ -145,7 +145,7 @@ defaults:
       show_meta: true   # Show metadata for all posts
       # sidebar:        # Possible values › left, right › by default there will be no sidebar
       comments: true
-      author: weaverbel     # Default author for posts
+      author: admin     # Default author for posts
 
 
 

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -6,7 +6,7 @@
 #
 # Resource › http://blog.sorryapp.com/blogging-with-jekyll/2014/02/06/adding-authors-to-your-jekyll-site.html
 admin: # replace this with your info
-  name: "The Carpentries Administrator"
+  name: "The Carpentries Team"
   siterole: "webmaster"
   uri: https://carpentries.org/
   email: team@carpentries.org

--- a/pages/pages-root-folder/atom.xml
+++ b/pages/pages-root-folder/atom.xml
@@ -41,7 +41,7 @@ permalink: /atom.xml
 			<title>{{ post.title | strip_html | strip_newlines | xml_escape }}</title>
 			<link href="{{ site.url }}{{ site.baseurl }}{{ post.url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
 			<updated>{{ post.date | date_to_xmlschema }}</updated>
-
+			{% comment %}
 			{% if post.author %}
 				{% assign author = site.data.authors[post.author] %}
 				<author>
@@ -58,15 +58,14 @@ permalink: /atom.xml
 					{% endif %}
 				</author>
 			{% endif %}
+			{% endcomment %}
+			{% for author in post.authors %}<author><name>{{author}}</name></author>{% endfor %}
 			<summary>{{ post.teaser | xml_escape }}</summary>
 			<content type="html" xml:base="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.content | xml_escape }}</content>
-
 			{% for category in post.categories %}
-				<category term="{{ category | xml_escape }}" />
-			{% endfor %}
+				<category term="{{ category | xml_escape }}" />{% endfor %}
 			{% for tag in post.tags %}
-				<category term="{{ tag | xml_escape }}" />
-			{% endfor %}
+				<category term="{{ tag | xml_escape }}" />{% endfor %}
 
 			<published>{{ post.date | date_to_xmlschema }}</published>
 		</entry>

--- a/pages/pages-root-folder/feed.xml
+++ b/pages/pages-root-folder/feed.xml
@@ -18,6 +18,9 @@ permalink: /feed.xml
 				<link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
 				<description>{{ post.content | xml_escape }}</description>
+				<author>{{post.authors | join: ", "}}</author>
+				{% for category in post.categories %}<category>{{ category | xml_escape }}</category>{% endfor %}
+				{% for tag in post.tags %}<category> {{ tag | xml_escape }} </category>{% endfor %}
 				<guid isPermaLink="true">{{ site.url }}{{ site.baseurl }}{{ post.url }}</guid>
 			</item>
 		{% endfor %}


### PR DESCRIPTION
* Put proper authors into feed.xml and atom.xml, using https://stackoverflow.com/questions/5855993/multiple-authors-in-rss-or-atoms as the pattern to go on. (Will test when patch is live in newsblur)
* Made default author "The Carpentries Team" instead of "weaverbel"
* Put proper categories into feed.xml, and removed a touch of whitespace from the template to reduce bandwidth use.

To test this, you can view a good rendering of the feed at https://www.newsblur.com/site/7032110/the-carpentries