### PR TITLE
Changed title to Trainer Training 2020

### DIFF
--- a/_posts/2019/11/2019-11-13-trainer-training-2019.md
+++ b/_posts/2019/11/2019-11-13-trainer-training-2019.md
@@ -2,7 +2,7 @@
 layout: page
 authors: ["Karen Word"]
 teaser: "Apply to become an Instructor Trainer and shape the next generation of Carpentries Instructors!"
-title: "Trainer Training 2019"
+title: "Trainer Training 2020"
 date: 2019-11-13
 time: "00:00:00"
 tags: ["Instructor Development", "Trainers"]


### PR DESCRIPTION
Since the training will begin in 2020, should we change the title? I should've asked this earlier, but it just popped up in the newsletter draft and wanted to check @karenword.