### PR TITLE
Announcing 2020 Executive Council 

### DIFF
--- a/_posts/2020/01/2020-01-02-executive-council-results.md
+++ b/_posts/2020/01/2020-01-02-executive-council-results.md
@@ -1,0 +1,38 @@
+---
+layout: page
+authors: ["Kate Hertweck", "Executive Council"]
+teaser: ""
+title: "Announcing the 2020 Executive Council for The Carpentries"
+date: 2020-1-02
+time: "05:00:00"
+tags: ["Community", "Executive Council"]
+---
+
+We are pleased to announce the results of the community and council elections for the 2020 Executive Council, which will assume responsibility of governance from the current Executive Council in February 2020.
+
+# Incoming community-elected members
+
+[Seven candidates](https://carpentries.org/blog/2019/12/executive-council-elections-2020/) stood for the community election held during the first week of December. Out of the 1248 ballots distributed to Voting Members, 419 ballots were cast (33.6% turnout). The two candidates receiving the highest number of votes and joining the Executive Council for two-year terms as community-elected Members are:
+
+- **Lex Nederbragt:** Senior lecturer at the Institute of Biosciences, University of Oslo, Norway.
+- **Paula Andrea Martinez:** Training Coordinator at the National Imaging Facility, Australia.
+
+
+# Incoming council-elected members
+
+The Executive Council received recommendations for eight individuals for the council-elected positions, and elected the following two Members from that set of nominees:
+
+- **Cedric Chambers:** Founder and CEO of JUMP Recruits in the United States. This organization develops and implements diversity recruitment programs for employers as well as offers the advice, support and training necessary for diverse candidates to excel in their careers.
+- **Konrad Förstner:** Professor for Information Literacy at the TH Köln – University of Applied Sciences and Head of Information Services at ZB MED - Information Centre for Life Sciences in Germany.
+
+# Continuing and outgoing Executive Council members
+
+The four new members listed above join the five continuing Executive Council members:
+
+- **Amy Hodge:** Science Data Librarian for Stanford University Libraries in the United States.
+- **Mesfin Diro Chaka:** Computational data scientist and faculty member at Addis Ababa University in Ethiopia.
+- **Elizabeth Wickes:** Lecturer at the School of Information Sciences at the University of Illinois in the United States.
+- **Joslynn Lee:** Assistant Professor in Biochemistry at Fort Lewis College in the United States. She is of the Diné (Navajo), K’awaika (Laguna Pueblo) and Haak’u (Acoma Pueblo) people.
+- **Juan Steyn:** Project manager at the South African Centre for Digital Language Resources (SADiLaR) hosted at the North-West University in South Africa.
+
+Thanks to the outgoing Executive Council members--Karen Cranston, Kate Hertweck, Raniere Silva--and to the entire Carpentries community for standing for election, recommending candidates, and submitting ballots!


### PR DESCRIPTION
Election results! The publish date is set to Jan 2, but feel free to adjust as necessary.

Tagging @amyehodge as FYI