### PR TITLE
Update jobs page

### DIFF
--- a/pages/Deputy-Director-of-Instructor-Training-job-posting.md
+++ b/pages/Deputy-Director-of-Instructor-Training-job-posting.md
@@ -4,6 +4,8 @@ title: "Deputy Director of Instructor Training"
 permalink: /deputy-director-of-instructor-training/
 ---
 
+Posting date: 26 November 2019
+
 [The Carpentries](http://carpentries.org) is committed to “training and fostering an active, inclusive, diverse community of 
 learners and instructors who promote and model the importance of software and data in research.” We seek an engaged and collaborative 
 individual who shares this vision for a full-time position as the Deputy Director of Instructor Training for The Carpentries. 

--- a/pages/communications-manager.md
+++ b/pages/communications-manager.md
@@ -4,6 +4,8 @@ title: "Communications Manager"
 permalink: /communications-manager/
 ---
 
+Posting date: 26 November 2019
+
 [The Carpentries](http://carpentries.org) is committed to “training and fostering an active, inclusive, diverse community of learners 
 and instructors who promote and model the importance of software and data in research.” We seek an engaged and collaborative individual
 who shares this vision for a full-time position as the Communications Manager for The Carpentries. The Communications Manager will

--- a/pages/jobs.md
+++ b/pages/jobs.md
@@ -12,25 +12,7 @@ and 85 member organisations from research institutions around the world. See bel
 The Carpentries seeks its next [Executive Director](http://www.marcumllp.com/executive-search/executive-director-the-carpentries) to spearhead the organisation's vision of becoming the leading inclusive community teaching data and coding skills. Tracy Teal, the current Executive Director, will depart the organisation in January 2020. Senior Director of Equity and Assessment Kari Jordan will serve as Interim Executive Director until the next Executive is hired. This position is remote, so all qualified candidates are encouraged to apply, regardless of location. We are working with the non-profit group of [Marcum LLP](http://www.marcumllp.com/) to coordinate the hiring process for this critical role. 
 
 ## Astronomy Curriculum Developer (US-based, 6 month position)
-We are seeking a [six-month part-time curriculum developer](https://carpentries.org/astronomy-curriculum-developer/), based in the United States, to create open-source Data Carpentry lessons in astronomy in advanced Python, data management, and data visualisation. Applications received before midnight Pacific January, 16 2020 will receive full consideration.
-
-## Deputy Director of Instructor Training
-We are hiring a [Deputy Director of Instructor Training](https://carpentries.org/deputy-director-of-instructor-training/) to support
-our global Instructor Training community, train and onboard new Instructor Trainers (who teach our Instructors), and develop an
-assessment strategy to examine the impact of our Instructor Training and Trainer Training programs.
-
-## Curriculum Development Roles  
-To support our Curriculum Development program, we are hiring two new team members. The
-[Curriculum Community Developer](https://carpentries.org/curriculum-community-developer/) will have a broad responsibility to develop
-community and guidelines around open, collaborative curriculum development within the scientific, open source software, and research
-ecosystem. They will work closely with the new
-[Lesson Infrastructure Technology Developer](https://carpentries.org/lesson-infrastructure-technology-developer),
-who will develop infrastructure and processes to support hosting, curation, and discoverability of community-developed lessons.
-
-## Communications Manager
-We are also hiring a [Communications Manager](https://carpentries.org/communications-manager/) to work closely with Serah Njambi Rono,
-our Community Engagement Lead, to develop and execute the day-to-day internal and external communications workflows necessary to keep
-our community informed and engaged.
+We are seeking a [six-month part-time curriculum developer](https://carpentries.org/astronomy-curriculum-developer/), based in the United States, to create open-source Data Carpentry lessons in astronomy in advanced Python, data management, and data visualisation. Applications received before midnight Pacific January 16 2020 will receive full consideration.
 
 Posting date: 26 November 2019
 Application review begins [11 December 2019](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20191211T235959&p1=3400). Positions will remain open until filled.

--- a/pages/jobs.md
+++ b/pages/jobs.md
@@ -14,6 +14,17 @@ The Carpentries seeks its next [Executive Director](http://www.marcumllp.com/exe
 ## Astronomy Curriculum Developer (US-based, 6 month position)
 We are seeking a [six-month part-time curriculum developer](https://carpentries.org/astronomy-curriculum-developer/), based in the United States, to create open-source Data Carpentry lessons in astronomy in advanced Python, data management, and data visualisation. Applications received before midnight Pacific January 16 2020 will receive full consideration.
 
+## Curriculum Development Roles  
+To support our Curriculum Development program, we are hiring two new team members. The
+[Curriculum Community Developer](https://carpentries.org/curriculum-community-developer/) will have a broad responsibility to develop
+community and guidelines around open, collaborative curriculum development within the scientific, open source software, and research
+ecosystem. They will work closely with the new Lesson Infrastructure Technology Developer, who will develop infrastructure and processes to support hosting, curation, and discoverability of community-developed lessons.
+
+## Communications Manager
+We are also hiring a [Communications Manager](https://carpentries.org/communications-manager/) to work closely with Serah Njambi Rono,
+our Community Engagement Lead, to develop and execute the day-to-day internal and external communications workflows necessary to keep
+our community informed and engaged.
+
 Posting date: 26 November 2019
 Application review begins [11 December 2019](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20191211T235959&p1=3400). Positions will remain open until filled.
 Apply by submitting a cover letter and resume or CV to [jobs@carpentries.org](mailto:jobs@carpentries.org). Please indicate all positions you are applying for in your cover letter. Please also clearly indicate the country in which you pay taxes.

--- a/pages/lesson-infrastructure-technology-developer.md
+++ b/pages/lesson-infrastructure-technology-developer.md
@@ -3,6 +3,7 @@ layout: page-fullwidth
 title: "Lesson Infrastructure Technology Developer"
 permalink: /lesson-infrastructure-technology-developer/
 ---
+Posting date: 26 November 2019
 
 [The Carpentries](http://carpentries.org) is committed to “training and fostering an active, inclusive, diverse community of learners
 and instructors who promote and model the importance of software and data in research.” We seek an engaged and collaborative individual


### PR DESCRIPTION
This PR addresses #661 

@kariljordan, it's a two-step process:

1. Update the individual jobs listings with information on when the role was first posted on the website ([see commit](https://github.com/carpentries/carpentries.org/commit/f3dd3f4dd6cbfaf0c3aa8e232996fc867eac5381))

2. Remove all links to positions we are no longer accepting applications for in the jobs page ([see commit](https://github.com/carpentries/carpentries.org/commit/4443b1271427b0c0540111ff2983b63a2b019e4b))

Please have a look and let me know if I can provide more clarity. Thanks for asking!
