### PR TITLE
scholarships --> financial aid

### DIFF
--- a/_posts/2019/12/2019-12-11-carpentrycon-financial-aid.md
+++ b/_posts/2019/12/2019-12-11-carpentrycon-financial-aid.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 authors: ["Christina Koch", "Gabriel Salubi"]
-teaser: "Submit your application to receive a scholarship to attend CarpentryCon from June 29 to July 1, 2020"
-title: "CarpentryCon 2020 Financial Aid Scholarship"
+teaser: "Submit your application to receive financial aid to attend CarpentryCon from June 29 to July 1, 2020"
+title: "CarpentryCon 2020 Financial Aid"
 date: 2019-12-11
 time: "00:00:00"
 tags: ["CarpentryCon", "Community"]
@@ -12,11 +12,11 @@ In order to promote as well as grow inclusive, computational communities and lea
 
 ![]({{ site.urlimg }}/blog/2019/12/why-attend-carpentrycon.png)
 
-These scholarships are aimed at, but not limited to postgraduate students, early-career researchers and academics who are unable to fully meet conference expenses through other funding means. Interested applicants should be able to demonstrate their potential for leadership and the creation of value for computational research by expanding the reach of the Carpentries in their communities and beyond.
+Financial aid is aimed at, but not limited to postgraduate students, early-career researchers and academics who are unable to fully meet conference expenses through other funding means. Interested applicants should be able to demonstrate their potential for leadership and the creation of value for computational research by expanding the reach of the Carpentries in their communities and beyond.
 
 In the interest of spreading our financial aid funding to its greatest extent, potential Carpentry Con attendees are encouraged to first exhaust other potential means of funding before applying for this grant. In the application form, it is possible to apply for various types of financial support, accommodating those who may be able to secure funding for one part of conference costs (like travel) but not another part (like the registration fee or visa costs).
 
-The total amount of funding for Carpentry Con 2020 scholarships will depend greatly on sponsorship and donations, so at this time we cannot how much money will be available per individual or how many individuals will receive financial support. This also means that financial support will likely be granted on a rolling basis, rather than all at once. We aim to keep both applicants and the broader community up-to-date as we progress towards the conference in June 2020. 
+The total amount of funding for Carpentry Con 2020 financial aid will depend greatly on sponsorship and donations, so at this time we cannot how much money will be available per individual or how many individuals will receive financial support. This also means that financial support will likely be granted on a rolling basis, rather than all at once. We aim to keep both applicants and the broader community up-to-date as we progress towards the conference in June 2020. 
 
 The application form is available here: [CarpentryCon 2020 Financial Support Application](https://docs.google.com/forms/d/e/1FAIpQLSf3vWlTy79TXAboT6VPElllq6ggYsSEb5QairmhU01kOHD_Dg/viewform).
 


### PR DESCRIPTION
Updating language used from "scholarships" to "financial aid" in reference to financial assistance for CarpentryCon 2020 attendees. As per @elizabethwilliams8 