### PR TITLE
Update 2019-10-21-transition-to-typeform.md

### DIFF
--- a/_posts/2019/10/2019-10-21-transition-to-typeform.md
+++ b/_posts/2019/10/2019-10-21-transition-to-typeform.md
@@ -56,6 +56,6 @@ We are planning on open-sourcing the code behind this before the end of the year
 
 ## Acknowledgments 
 
-The presentation of the survey results was developped using feedback and ideas from members of The Carpentries community including Ben Marwick, Katrin Leinweber, and Katrin Tirok.
+The presentation of the survey results was developed using feedback and ideas from members of The Carpentries community including Ben Marwick, Katrin Leinweber, and Katrin Tirok.
 
 For any other questions about this new system, please reach out to [team@carpentries.org](mailto:team@carpentries.org).


### PR DESCRIPTION
Found this typo also on the Shiny app ,but I can't find the code for it. See the bottom of the link I paste:
https://workshop-reports.carpentries.org/
