### PR TITLE
Promote GH-org-wide OpenSearch plugin 

### DIFF
--- a/_includes/_google_search.html
+++ b/_includes/_google_search.html
@@ -10,7 +10,7 @@
 </script>
 
 <form id="search" onsubmit="google_search(); return false;">
-    <label for="google-search">What are you looking for?</label>
+        <label for="Search">What are you looking for on our homepage?</label>
 	<input type="text" id="google-search" placeholder="{{ site.data.language.enter_search_term }}">
 </form>
 <noscript>

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,0 +1,3 @@
+<div markdown="0">
+	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install<a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.
+</div>

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,4 +1,4 @@
-<link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102071/carpen-verse.xml" hreflang="en" />
+<link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102146/carpen-verse.xml" hreflang="en" />
 
 <div markdown="0">
 	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install <a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,4 +1,4 @@
-<link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102146/carpen-verse.xml" hreflang="en" />
+<link rel="search" type="application/opensearchdescription+xml" href="https://mycroftproject.com/installos.php/102146/carpen-verse.xml" hreflang="en">
 
 <div markdown="0">
 	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install <a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,5 +1,4 @@
-<link rel="search" type="application/opensearchdescription+xml" href="https://mycroftproject.com/installos.php/102146/carpen-verse.xml" hreflang="en">
-
+ <link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102146/carpen-verse.xml" hreflang="en" />
 <div markdown="0">
 	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install <a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.
 </div>

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,5 +1,5 @@
 <link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102071/carpen-verse.xml" hreflang="en" />
 
 <div markdown="0">
-	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install<a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.
+	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install <a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.
 </div>

--- a/_includes/_search_plugin.html
+++ b/_includes/_search_plugin.html
@@ -1,3 +1,5 @@
+<link rel="search" type="application/opensearchdescription+xml" title="CarpenVerse" href="https://mycroftproject.com/installos.php/102071/carpen-verse.xml" hreflang="en" />
+
 <div markdown="0">
 	In order to find existing lesson repositories across our various GitHub organizations, material within episodes and related discussions right in your browser, you can install<a href="https://mycroftproject.com/search-engines.html?name=carpenverse">the "CarpenVerse" search plugin</a>.
 </div>

--- a/pages/search.html
+++ b/pages/search.html
@@ -6,3 +6,7 @@ sitemap: false
 ---
 
 {% include _google_search.html %}
+
+In order to find existing lesson repositories across our various GitHub organizations,
+material within episodes and related discussions, right in your browser, you can install
+[the "CarpenVerse" search plugin](https://mycroftproject.com/search-engines.html?name=carpenverse).

--- a/pages/search.html
+++ b/pages/search.html
@@ -7,6 +7,4 @@ sitemap: false
 
 {% include _google_search.html %}
 
-In order to find existing lesson repositories across our various GitHub organizations,
-material within episodes and related discussions, right in your browser, you can install
-[the "CarpenVerse" search plugin](https://mycroftproject.com/search-engines.html?name=carpenverse).
+{% include _search_plugin.html %}


### PR DESCRIPTION
This was discussed a bit in https://carpentries.topicbox.com/groups/discuss/Ta3b20a51cb1ba874/search-across-all-carpentries-github-organizations, but mentioning the plugin here is an alternative, simpler approach.

I'm hoping this will prove useful to others in finding existing lesson material, or discussions across all Carpentries GH orgs.

In case the plugin's name should be different, please feel free to post other suggestions below and vote on them.