### PR TITLE
make wkshp table exclude events w/o instructors

### DIFF
--- a/_includes/workshop_table.md
+++ b/_includes/workshop_table.md
@@ -1,5 +1,7 @@
 <table class="table table-striped" style="width: 100%;">
 {% for w in workshop_list  %}
+      {% if w.instructors %}
+
      {% assign asterisks = "" %}
      
      {% assign tags = w.tag_name | split: "," | downcase %}
@@ -42,6 +44,7 @@
 	</td>
 	</tr>
 
+      {% endif %}
 {% endfor %}
 </table>
 


### PR DESCRIPTION
This PR wraps the whole `workshop_table` in an `{% if w.instructors %}` clause, making it only display workshops with instructors. 