### PR TITLE
ignore .jekyll-cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ flycheck_*.el
 .dir-locals.el
 Gemfile.lock
 /.jekyll-metadata
+.jekyll-cache/


### PR DESCRIPTION
This is autogenerated when previewing with "jekyll serve" locally.