### PR TITLE
Update to Australia page

### DIFF
--- a/pages/regional_AU.html
+++ b/pages/regional_AU.html
@@ -70,14 +70,6 @@ Want to stay up-to-date with what's happening in the Australian Carpentries comm
 
     <tr>
       <td>
-        <a href="https://resbaz.github.io/resbaz2020/sydney/">RezBaz Sydney</a>
-      </td>
-      <td>
-        7-10 Jul, 2020
-      </td>
-    </tr>
-        <tr>
-      <td>
         <a href="https://resbaz.github.io/resbaz2020/brisbane/">RezBaz Brisbane</a>
       </td>
       <td>


### PR DESCRIPTION
ResBaz Sydney has been cancelled due to COVID-19. This PR removes it from the Australia page.