### PR TITLE
shows globe icon for online workshops

### DIFF
--- a/_includes/workshop_table.md
+++ b/_includes/workshop_table.md
@@ -32,7 +32,7 @@
       {% endunless %}
 
       {% if tags contains "online" %}
-      <img src="{{site.url}}/assets/img/flags/{{site.flag_size}}/w3.png" title="Online" alt="{{w.country | replace: '-', ' ' | downcase}}"  class="flags"/>
+      <img src="{{site.url}}/assets/img/flags/{{site.flag_size}}/w3.png" title="Online" alt="globe image" class="flags"/>
       {% endif %}
 
       <a href="{{w.url}}">{{ w.venue | strip_html }}{{ asterisks }}</a>

--- a/_includes/workshop_table.md
+++ b/_includes/workshop_table.md
@@ -25,10 +25,16 @@
     <td>
         <img src="{{site.url}}/assets/img/logos/{{ workshop_type }}.svg" title="{{ workshop_type }} workshop" alt="{{ workshop_type  }} logo" width="24" height="24" class="flags"/>
     </td>
+
     <td>
-        {% unless w.country == "" %}
+        {% unless w.country == "" or w.country == "W3" %}
       <img src="{{site.url}}/assets/img/flags/{{site.flag_size}}/{{w.country | downcase}}.png" title="{{w.country | replace: '-', ' '}}" alt="{{w.country | replace: '-', ' ' | downcase}}"  class="flags"/>
       {% endunless %}
+
+      {% if tags contains "online" %}
+      <img src="{{site.url}}/assets/img/flags/{{site.flag_size}}/w3.png" title="Online" alt="{{w.country | replace: '-', ' ' | downcase}}"  class="flags"/>
+      {% endif %}
+
       <a href="{{w.url}}">{{ w.venue | strip_html }}{{ asterisks }}</a>
       {% if w.instructors %}
           <br/>


### PR DESCRIPTION
This is the proposed way that online workshops will show on our website.  It adds a globe icon next to the country flag for online workshops.  If no country is listed for an online workshop, only the globe icon appears.  

@sheraaronhurt  what do you think on behalf of the workshop admin team? Would you also want to see the text "(online)" appear next to the venue name? 

![image](https://user-images.githubusercontent.com/829690/80999978-8d0a3280-8e13-11ea-8133-2c3fcb9f7b3a.png)


 
