### PR TITLE
Highlight resources for online workshops on our homepage

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -115,6 +115,30 @@ format: frontpage
     </div><!-- /.row -->
 {% endunless %}
 
+{% comment %}
+Content for Online Workshops
+{% endcomment %}
+
+<div class="row">
+  <h2> Resources for Online Workshops</h2><br>
+</div>
+<div class="row">
+    <div class="medium-6 columns">
+
+        <h3><a href="{{ site.url }}{{ site.baseurl }}/online-workshop-recommendations/">Official Carpentries' Recommendations</a></h3>
+        <p>
+            This page holds an official set of recommendations by The Carpentries to help you organise and run Online Carpentries workshops. The page is updated periodically as we continue to receive input and feedback from our community.<br> <a href="{{ site.url }}{{ site.baseurl }}/online-workshop-recommendations/">Go to Page</a>.
+        </p>
+    </div><!-- /.medium-5.columns -->
+
+    <div class="medium-6 columns">
+        <h3><a href="https://docs.carpentries.org/topic_folders/hosts_instructors/resources_for_online_workshops.html">Community-Created Resources</a></h3>
+        <p>
+          This resource is a section in our Handbook containing an evolving list of all community-created resources and conversations around teaching Carpentries workshops online. The section is updated periodically to include newer resources and emerging conversations on the subject. <a href="https://docs.carpentries.org/topic_folders/hosts_instructors/resources_for_online_workshops.html">Go to Page</a>.
+        </p> 
+    </div><!-- /.medium-7.columns -->
+</div><!-- /.row -->
+
 
 {% comment %}
  list of workshops

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -129,14 +129,14 @@ Content for Online Workshops
         <p>
             This page holds an official set of recommendations by The Carpentries to help you organise and run Online Carpentries workshops. The page is updated periodically as we continue to receive input and feedback from our community.<br> <a href="{{ site.url }}{{ site.baseurl }}/online-workshop-recommendations/">Go to Page</a>.
         </p>
-    </div><!-- /.medium-5.columns -->
+    </div><!-- /.medium-6.columns -->
 
     <div class="medium-6 columns">
         <h3><a href="https://docs.carpentries.org/topic_folders/hosts_instructors/resources_for_online_workshops.html">Community-Created Resources</a></h3>
         <p>
           This resource is a section in our Handbook containing an evolving list of all community-created resources and conversations around teaching Carpentries workshops online. The section is updated periodically to include newer resources and emerging conversations on the subject. <a href="https://docs.carpentries.org/topic_folders/hosts_instructors/resources_for_online_workshops.html">Go to Page</a>.
         </p> 
-    </div><!-- /.medium-7.columns -->
+    </div><!-- /.medium-6.columns -->
 </div><!-- /.row -->
 
 


### PR DESCRIPTION
This is the last of two steps outlined in https://github.com/carpentries/docs.carpentries.org/issues/580, and resolves carpentries/carpentries.org#745

What this PR does

- [x] on the homepage of our website, carpentries.org, create a new section right above the Upcoming Workshops section and add a blurb about the official recommendations page on the left half, and a blurb about the aggregated resources page on the right half.

How this now looks:
<img width="1065" alt="Screenshot 2020-05-08 at 13 02 19" src="https://user-images.githubusercontent.com/4550385/81395369-2bf0a080-912c-11ea-8818-f115e4ca19d6.png">
