### PR TITLE
use h3 level headers for questions, add toc

### DIFF
--- a/pages/workshop_faq.md
+++ b/pages/workshop_faq.md
@@ -4,23 +4,25 @@ title: "FAQ For Workshop Coordination"
 permalink: /workshop_faq/
 ---
 
-* [Pre-Workshop](#pre-workshop-questions)
-* [Curriculum](#curriculum)
-* [Centrally Organised Workshops](#centrally-organised-workshops)
-* [Self Organised Workshops](#self-organised-workshops)
-* [Online Workshops](#online-workshops)
-* [Miscellaneous](#miscellaneous)
-
+<div class="panel radius" markdown="1">
+**Table of Contents**
+{: #toc }
+*  TOC
+{:toc}
+</div>
 
 ## Pre-Workshop Questions
 
-**Why isn't my workshop listed on the [carpentries.org](http://carpentries.org) webpage?**<br>
+### Why isn't my workshop listed on the [carpentries.org](http://carpentries.org) webpage?
+
 There are 3 things that must happen in order for a workshop to appear on The Carpentries webpage. You must complete the [workshop request/notification form](https://amy.carpentries.org/forms/workshop/), the workshop website must include the venue, and at least one Instructor must be identified. If the Instructors change, we will get notified and will be able to make the update. 
 
-**If I am teaching a Data Carpentry Genomics workshop, how many AWS Instances will be provided and when will we receive them?**<br>
+### If I am teaching a Data Carpentry Genomics workshop, how many AWS Instances will be provided and when will we receive them?
+
 A member of the Workshop Administration Team will contact the Hosts/Instructors approximately 2-3 weeks prior to the workshop to find out how many instances are needed. You will be asked to provide the total number of Instructors, helpers and learners. Approximately 1 week prior to the workshop, the Workshop Administration Team will provide you with test instances for each Instructor and helper for testing/practice. Approximately 3 days before the workshop, you will be asked for your final attendance so we can send you the AWS instances for the workshop. On the day prior to the workshop, the Workshop Administration Team will provide you with instances for each Instructor, helper and learner for the workshop. We will also send a few extras for backup. The AWS Instances will be terminated the day after the workshop.  Please submit your workshop request/notification form at least 21 days in advance.
 
-**What is a slug? And how should I use it to name my workshop website?**<br>
+### What is a slug? And how should I use it to name my workshop website?
+
 A slug is a unique identifier used by The Carpentries to connect a workshop with an organisation. Each workshop will have its own slug. The slug should use the following format YEAR-MM-DD-SITE-(online).
 
 * YEAR being replaced by the four-digit year (e.g. *2020*)
@@ -31,87 +33,109 @@ A slug is a unique identifier used by The Carpentries to connect a workshop with
 
 This slug format is a part of a validation check in our system, including the dashes separating these variables.
 
-**Should the Instructor or a member of the host institution be listed as the contact person on the workshop webpage ?**<br>
+### Should the Instructor or a member of the host institution be listed as the contact person on the workshop webpage ?
+
 The contact person for the workshop webpage can be designated by the workshop organiser. The person listed should be able to answer questions regarding the workshop, such as attendance policy, waitlist, location, installation, etc. You can have multiple persons listed as the contact person if needed.
 
-**Where do I find the pre/post survey for the learners to use?**<br>
+### Where do I find the pre/post survey for the learners to use?
+
 The learner facing survey links are automatically generated on the workshop's webpage. Generally, they will be located directly above and within the schedule. You are welcome to share the survey links (located on the workshop webpage) with your attendees whenever the time is right for your workshop. 
 
-**How do I access the survey results?**<br>
+### How do I access the survey results?
+
 If you are planning a workshop, please notify the Workshop Administration Team of your planned workshop using the [workshop request form](https://amy.carpentries.org/forms/workshop/). The Workshop Administration Team will send the link to view results of the survey 1-2 weeks prior to the workshop. If there are more than 10 survey responses, you will have the option to download the survey data, using the "Download CSV" link at the bottom right of the survey results page.
 
 ## Curriculum
 
-**If I am only teaching portions of the Carpentries curriculum, do I still need to register my workshop?**<br>
+### If I am only teaching portions of the Carpentries curriculum, do I still need to register my workshop?
+
 It is important that we know about workshops being publicised because people often contact us to report that they will be unable to attend a workshop or to ask questions and if we do not know about planned workshops we can not provide support or share information with Instructors. 
 
 If you are teaching a portion of The Carpentries curriculum or if the workshop does not align with the [Core Curriculum](https://carpentries.org/workshops/#workshop-core) we ask that you still [register](https://amy.carpentries.org/forms/self-organised/) your workshop and select the “Mix & Match” option for the question “Which Carpentries workshop are you teaching?”. *This option is only available for Self-Organised workshops. Centrally-organised workshops are required to follow the Core Curricula.*
 
-**When we teach our workshops, how closely do we have to stick to the Carpentries lesson plans?**<br>
+### When we teach our workshops, how closely do we have to stick to the Carpentries lesson plans?
+
 To be considered an official Carpentries workshop, you must follow the [Core Curricula](https://carpentries.org/workshops/#workshop-core). If you teach something other than what is listed on our webpage we ask that you acknowledge that your workshop is  "inspired by SWC/DC/LC" or "based on SWC/DC/LC". You can still [register](https://amy.carpentries.org/forms/self-organised/) your workshop and select the workshop you are teaching is “Mix & Match”, so that we can show others how you use The Carpentries resources. 
 
 ## Centrally Organised Workshops
 
-**How much does a workshop cost?**<br>
+### How much does a workshop cost?
+
 If you are a government or non-profit institution and would like The Carpentries to assist with organising your workshop, there is an administrative fee of $2500 US. You will also be responsible for the travel expenses for each Instructor (see below). If you are a for-profit institution please [contact us](mailto:team@carpentries.org). 50% of workshop coordination fees for for-profit institutions support workshops in diverse communities.
 
 Please visit our [website](https://carpentries.org/workshops/#workshop-cost) for more information. 
 
-**Do Instructors pay for travel?**<br>
+### Do Instructors pay for travel?
+
 Our Instructors are volunteers and are not paid for their time teaching. Therefore we ask the host to cover travel and accommodation costs for Instructors assigned to teach at your institution. We work to find local Instructors but suggest that you estimate about $2000 total ($1000 per Instructor) for the travel, food, and accommodation of the Instructors. **Note travel and accommodation costs might vary globally.**
 
 The details of how you will manage the Instructors’ travel is discussed once the Instructors are confirmed and introduced to the host. *The Carpentries is not involved in this process.*
 
-**Who can be a Helper and what do they contribute to the workshop?**<br>
+### Who can be a Helper and what do they contribute to the workshop?
+
 Helpers are often recruited from the local community at the host site to support Carpentries workshops. Helpers support learners one-on-one if they are stuck installing software, understanding a certain line of code, or any other parts of the learning process. [Here](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) is more information regarding helpers.
 
-**Are Helpers reimbursed for travel?** <br>
+### Are Helpers reimbursed for travel?
+
 The Carpentries is not responsible for selecting Helpers. This is the responsibility of the host organisation. It is the discretion of the organisation if they would like to reimburse the helpers for travel. [Here](https://docs.carpentries.org/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) is more information regarding helpers.
 
-**As an Instructor, will I still get credit for a workshop if the host cancelled?** <br>
+### As an Instructor, will I still get credit for a workshop if the host cancelled?
+
 If you are scheduled to teach a Carpentries workshop and the host cancels, you will still receive credit for the workshop. If a workshop is scheduled and you have to resign from teaching, you will not receive credit for the workshop.
 
-**How soon can I request a Carpentries workshop?**<br>
+### How soon can I request a Carpentries workshop?
+
 The Carpentries workshops are offered on-demand, not on a set schedule. We ask for a minimum of 2-3 months lead time to organise the workshop. If a request is less than 2 months, there will be no guarantee that we will be able to provide Instructors for your workshop. 
 
-**My currency is not USD, will I get invoiced in USD or my local currency?**<br>
+### My currency is not USD, will I get invoiced in USD or my local currency?
+
 If your organization does not accept invoices in USD, please let us know. The Workshop Administration Team will connect you with the Business Team, who will work with you in coordinating invoicing. To keep workshops accessible, The Carpentries will take responsibility for standard fees that arise due to an organisation’s location outside of the US. We see this as a good business practice within a global community.
 
 ## Self Organised Workshops
 
-**Is there a fee for running a Self-Organised workshop?** <br>
+### Is there a fee for running a Self-Organised workshop?
+
 Self-organised workshops are managed by the instructor/organiser. Since you will be taking care of all the logistics, there is no administrative fee due to The Carpentries for running a Self-Organised workshop. Visit our [website](https://carpentries.org/workshops/#workshop-organising) for more information. 
 
-**How do I inform you I am running a self-organised workshop?** <br>
+### How do I inform you I am running a self-organised workshop?
+
 When planning a Self-Organised workshop we ask that you notify us of your planned workshop. Once the workshop webpage is created, please share the link with us and notify us of your planned workshop via the [self-organised workshop form](https://amy.carpentries.org/forms/self-organised/). Once we receive the link to the workshop webpage, we will be able to [add your workshop to our website](https://carpentries.org/upcoming_workshops/), provide support (in the form of survey result links and AMI instances for Genomics workshops), and get Instructors and helpers credit for the workshops they teach. 
 
 ## Online Workshops
 
-**I have never taught an online workshop, where should I begin?** <br>
+### I have never taught an online workshop, where should I begin?
+
 It is required that experienced Instructors (have taught **three** or more Carpentries workshops) teach online workshops. If you have not taught three Carpentries workshops you are encouraged to be a Supporting Instructor (see below). All Instructors should be familiar with the [Recommendation for Teaching Carpentries Workshops Online](https://carpentries.org/online-workshop-recommendations/).
 
-**What is a Supporting Instructor?**<br>
+### What is a Supporting Instructor?
+
 The Supporting Instructor role is intended for Instructors with less practice teaching Carpentries curricula to offer experience with online workshops. It also ensures that the instructional team consists of several Carpentries-trained participants. The Supporting Instructor role will be assigned to certified Carpentries Instructors who have taught less than three workshops.
 
-**When can a Supporting Instructor become an Experienced Instructor?** <br>
+### When can a Supporting Instructor become an Experienced Instructor?
+
 Ater being a Supporting Instructor for three Carpentries workshops you will be able to take the role of Experienced Instructor in any Carpentries online workshop. If you would like to continue in the Supporting Instructor role, please indicate your preference on the Instructor signup sheet. 
 
-**How do I indicate my workshop will be online in the workshop website template?**<br>
+### How do I indicate my workshop will be online in the workshop website template?
+
 We updated the [workshop website template](https://github.com/carpentries/workshop-template) to make it easier to indicate that a workshop will be taught online. Instructions to customise your workshop website are available on the [customisation page](http://carpentries.github.io/workshop-template/customization/index.html).
 
-**Does the workshop have to be 2 full days?** <br>
-Your workshop does not have to be 2 full days. You are encouraged to  conduct your workshop over 4 half days if necessary. This is up to the discretion of the workshop organiser/Instructors and the needs of the audience.  
+### Does the workshop have to be 2 full days?
 
-**Will I be provided with a Zoom room to run my online workshop?** <br>
+Your workshop does not have to be 2 full days. You are encouraged to  conduct your workshop over 4 half days if necessary. This is up to the discretion of the workshop organiser/Instructors and the needs of the audience.
+
+### Will I be provided with a Zoom room to run my online workshop?
+
 Self-Organised workshops are managed by the instructor/organiser, who is responsible for taking care of all the logistics. This means you will be responsible for providing your own Zoom room for conducting workshops. Please be sure to review our [Recommendations for Teaching Carpentries Workshops Online](https://carpentries.org/online-workshop-recommendations/). 
 
 For Centrally-Organised workshops, if your institution has a videoconferencing platform available, we recommend that you use that same platform for The Carpentries workshop. This will reduce the time needed for workshop organizers and learners to learn a new system. However, if you do not have access to a video conferencing system, we will be able to provide you with access to one of our Zoom rooms. 
 
-**How many Instructors are needed to teach the workshop?**<br>
+### How many Instructors are needed to teach the workshop?
+
 Teaching online is a challenge. We recommend a minimum of two Instructors and a maximum of four Instructors plus the assistance of helpers. Please review the recommended [instruction roles](https://carpentries.org/online-workshop-recommendations/#instructional-roles) for a workshop. 
 
 
-**What are the roles of everyone participating in a workshop?**<br>
+### What are the roles of everyone participating in a workshop?
+
 *Instructor*: A person who has been certified by The Carpentries and understands best practices as outlined by The Carpentries Curricula. These persons will lead the workshop and teach the scheduled lessons. 
 
 *Supporting Instructor*: A certified Carpentries Instructor who has taught The Carpentries workshops less than 3 times. These persons are gaining experience while observing and teaching portions of the scheduled lessons.
@@ -123,44 +147,48 @@ Teaching online is a challenge. We recommend a minimum of two Instructors and a 
 *Workshop Organiser/Host*: The person who requested The Carpentries workshop. This person is the main contact for the workshop and will be able to provide logistical support for attending the scheduled workshop.
 
 ## Miscellaneous
-**What happens if I need to cancel or postpone a planned workshop?** <br> 
+
+### What happens if I need to cancel or postpone a planned workshop?
+
 If you need to cancel your workshop, please be sure to inform your [Regional Coordinator](https://carpentries.org/regionalcoordinators/). They will ensure that the workshop is removed from our website and complete any other administrative tasks associated with the workshop. 
 
 If you need to postpone your workshop please contact your [Regional Coordinator](https://carpentries.org/regionalcoordinators/). They will work with you to select the dates for the rescheduled workshop. 
 
-**What is the difference between a Centrally-Organised workshop and a Self-Organised workshop?** <br>
+### What is the difference between a Centrally-Organised workshop and a Self-Organised workshop?
+
 A Centrally-Organised workshop is organised by The Carpentries. We will locate Instructors, setup registration and provide additional support while planning workshops. There is an [administrative fee](https://carpentries.org/workshops/#workshop-cost) for Centrally-Organised workshops. 
 
 A Self-Organised workshop is organised by the workshop instructor/organiser. This means you are already connected with our [certified Instructors](https://carpentries.org/instructors/) and will work with them on all aspects of workshop organisation. There is no administrative fee for Self-Organised workshops. 
 
-**How do I get survey data/links for previous workshops?** <br>
+### How do I get survey data/links for previous workshops?
+
 The Workshop Administration Team can provide survey result links for past workshops (August 2018 - present) to workshop instructors/organizers or instructors affiliated with the hosting organisation. To request survey results links, please send an email to the Workshop Administration Team (via team@carpentries.org) with your request and include a link to the workshop website(s) and/or slug(s).
 
-**Can we restrict who participates in our workshops?**<br>
+### Can we restrict who participates in our workshops?
+
 Yes, it is up to the workshop organisers to decide who can attend a workshop. You can have it open to the public or restricted to people from your organisation. When you [request](https://amy.carpentries.org/forms/request_workshop/) or [register](https://amy.carpentries.org/forms/self-organised/) your workshop, you can indicate if the workshop is open to the public or not. 
 
-**How many times a year do I have to teach to be eligible to vote?**<br>
+### How many times a year do I have to teach to be eligible to vote?
+
 Voting eligibilty is dependent on an Instructor's history with The Carpentries. Please see our [Bylaws](https://docs.carpentries.org/topic_folders/governance/bylaws.html#individual-voting-membership) for more information. 
 
-**Are there email templates available for me to locate helpers?** <br>
+### Are there email templates available for me to locate helpers?
+
 We have compiled several [email templates](https://docs.carpentries.org/topic_folders/workshop_administration/email_templates.html#from-instructors-and-hosts) for you to be able to respond to various groups: participants, instructors, and helpers. 
 
-**I do not see a [Regional Coordinator](https://carpentries.org/regionalcoordinators/) for my area. Who should I speak with regarding a workshop?** <br>
+### I do not see a [Regional Coordinator](https://carpentries.org/regionalcoordinators/) for my area. Who should I speak with regarding a workshop?
+
 If you live in an area that does not have a Regional Coordinator in that region, you are welcome to contact the Deputy Director of Workshops & Meetings at [team@carpentries.org](mailto:team@carpentries.org). This person is responsible for all workshops that do not have a Regional Coordinator. 
 
-**Can I charge Learners a fee to attend a workshop I host?**<br>
+### Can I charge Learners a fee to attend a workshop I host?
+
 Yes, you can charge learners a fee to attend a workshop. It is up to the Host to decide if they will charge each participant. Often a nominal fee of $20 reduces the number of no-shows. Since most workshops have a wait list, it is best to be able to offer these spots to people on the wait list instead of having an empty seat.
 
-**Can I pay Instructors a stipend?**<br>
+### Can I pay Instructors a stipend?
+
 The Instructors selected to teach workshops are volunteers and are not paid for their service. To compensate for their time we require the Host to cover travel expenses. If you would like to support our Instructors, you are encouraged to make a targeted [donation](https://carpentries.org/donate/) to The Carpentries to support instructor development.
 
 
 ## Further Resources
+
 See our [Membership FAQ page](https://static.carpentries.org/member_faq/) for frequently asked questions specifically relevant to Carpentries Member Organisations.
-
-    
-
-
-
-
-


### PR DESCRIPTION
Using level-3 headers for the questions means that we can link directly to a particular question using anchors and improves accessibility. I also added a table of contents at the top to browse the content more easily.
