### PR TITLE
Redirect Donate link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -107,7 +107,7 @@
   - title: "Community Calendar"
     url: "/community/#community-events"
   - title: "Community Discussions"
-    url: "/community_discussions"  
+    url: "/community_discussions"
   - title: "Community Handbook"
     url: "https://docs.carpentries.org/"
   - title: "Newsletter"
@@ -116,7 +116,7 @@
     url: "https://twitter.com/thecarpentries/"
 
 - title: "Donate"
-  url: "/donate/"
+  url: "https://carpentries.wedid.it"
   side: right
 
 - title: "Search"


### PR DESCRIPTION
Rather than having two clicks to go to the Donate page, we will have the donate button go directly to the donate page
