### PR TITLE
add note to top of workshop table

### DIFF
--- a/_includes/workshop_table.md
+++ b/_includes/workshop_table.md
@@ -1,3 +1,5 @@
+Click on an individual event to learn more about that event, including contact information and registration instructions.
+
 <table class="table table-striped" style="width: 100%;">
 {% for w in workshop_list  %}
       {% if w.instructors %}


### PR DESCRIPTION
Adds a note to the top of the workshop table reminding users to click on the workshop to get more information.