### PR TITLE
Promote community lessons page

### DIFF
--- a/pages/involved_lessons.md
+++ b/pages/involved_lessons.md
@@ -6,11 +6,11 @@ permalink: "/involved-lessons/"
 
 ## Suggest an improvement to an existing lesson
 
-The Carpentries lessons are collaboratively developed - anyone can contribute and we receive contributions daily. 
+The Carpentries lessons are collaboratively developed - anyone can contribute and we receive contributions daily.
 All of our lessons are on GitHub and [creating an account][join-github] is required to contribute directly to the lessons. To fix a typo,
-correct an 
-error, clarify an example, or otherwise suggest an improvement to an existing lesson, you can file an issue on the lesson's GitHub 
-repository. For typo fixes and error corrections, pull requests are also welcome! For suggestions, and to propose large-scale changes, 
+correct an
+error, clarify an example, or otherwise suggest an improvement to an existing lesson, you can file an issue on the lesson's GitHub
+repository. For typo fixes and error corrections, pull requests are also welcome! For suggestions, and to propose large-scale changes,
 please start a conversation through an issue rather than putting in a pull request. This gives the lesson Maintainers and the rest of the
 community an opportunity to discuss the suggestion before you've done all of the work. If you're not familiar with GitHub, you can
 also submit a comment or question through one of our [communication channels][comms].
@@ -21,11 +21,11 @@ For more details on the workflow of how to contribute via GitHub, see this commu
 
 Any lesson that uses The Carpentries [lesson template][lesson-template], follows our [Code of Conduct][coc], and is licensed either [CC-BY][cc-by] or [CC-0][cc-0] can be hosted in The Carpentries Incubator. You can learn more about The Carpentries approach to curriculum development in our [Curriculum Development Handbook][cdh].
 
-The goal of The Carpentries Incubator is to be a place for Carpentries community members to share resources in early stages of development. People already familiar with The Carpentries teaching practices can pick them up and teach them in meetups, in class, or in complement of a ["standard" Carpentries 2-day workshop](/workshops/#workshop-core). The lessons can also be used by independent learners, outside of workshops.  Read more about how to contribute to these lessons in [The Carpentries Incubator Proposals Repository on GitHub](https://github.com/carpentries-incubator/proposals#readme).
+The goal of The Carpentries Incubator is to be a place for Carpentries community members to share resources in early stages of development. The [Community Developed Lessons][community-lessons] page lists all lessons currently hosted in The Carpentries Incubator. People already familiar with The Carpentries teaching practices can pick them up and teach them in meetups, in class, or in complement of a ["standard" Carpentries 2-day workshop](/workshops/#workshop-core). The lessons can also be used by independent learners, outside of workshops.  Read more about how to contribute to these lessons in [The Carpentries Incubator Proposals Repository on GitHub](https://github.com/carpentries-incubator/proposals#readme).
 
-In the near future, we will also provide a friendly, community-supported, peer-review process for lessons. 
+In the near future, we will also provide a friendly, community-supported, peer-review process for lessons.
 After the peer-review process, the lessons will be hosted in [The Carpentries Lab][carpentries-lab] and will be officially endorsed
-by The Carpentries as high-quality resources. At this time, we are not accepting lesson submissions to The CarpentriesLab. If you 
+by The Carpentries as high-quality resources. At this time, we are not accepting lesson submissions to The CarpentriesLab. If you
 are interested in having a lesson reviewed for inclusion in The Lab, please submit it first to The Incubator through our
 [GitHub Repository](https://github.com/carpentries-incubator/proposals#readme).
 
@@ -39,5 +39,6 @@ are interested in having a lesson reviewed for inclusion in The Lab, please subm
 [carpentries-lab]: https://github.com/carpentrieslab/proposals
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-summary-view
 [comms]: https://carpentries.org/connect/
+[community-lessons]: https://carpentries.org/community-lessons/
 [issues]: https://github.com/carpentries-incubator/proposals/issues
 [lesson-template]: https://github.com/carpentries/styles

--- a/pages/workshops-curricula.md
+++ b/pages/workshops-curricula.md
@@ -19,73 +19,91 @@ permalink: /workshops-curricula/
 ### <a id="dc-ecology"></a> Data Carpentry: Ecology
 This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting (with your
 choice of R or Python). This workshop is intended for anyone working with tabular data (data with rows and columns, e.g. Excel). The data
-used for this workshop is an ecology dataset - counts of animal species that were observed in different locations over time, along with 
+used for this workshop is an ecology dataset - counts of animal species that were observed in different locations over time, along with
 information about their sex, weight, etc. This data is easily understandable by non-ecologists and is considered our most general-purpose
-workshop. 
+workshop.
 
 ### <a id="dc-genomics"></a>Data Carpentry: Genomics
 This workshop is intended for people working with high-throughput sequencing data and focuses on helping them upgrade their workflow from
-relying on spreadsheets and GUI platforms to using command-line tools and remote computing power. This workshop is taught using Amazon 
-Web Services. Learners will be introduced to core Bash commands and will learn to write custom Bash scripts to automate an analysis 
+relying on spreadsheets and GUI platforms to using command-line tools and remote computing power. This workshop is taught using Amazon
+Web Services. Learners will be introduced to core Bash commands and will learn to write custom Bash scripts to automate an analysis
 pipeline. They will be introduced to some commonly used command-line bioinformatics tools and file formats. This workshop does not cover
-individual methods for working with RNA-seq, ChIP-seq, or other specialized datasets, but instead focuses on core principles for 
+individual methods for working with RNA-seq, ChIP-seq, or other specialized datasets, but instead focuses on core principles for
 efficient and reproducible research with sequencing data.
 
 ### <a id="dc-geospatial"></a>Data Carpentry: Geospatial
 This workshop is intended for people working with geospatial data (i.e. data that can be plotted on a map). It starts out with a short
-introduction to essential geospatial concepts and a shortened version of our core R lesson before progressing into working with 
-specialized geospatial packages in R. This workshop gets learners to a fairly advanced stage of creating geospatial plots (i.e. maps of 
-data distributions), but does not cover data organisation or cleaning. For a more general workshop covering these topics, please check 
+introduction to essential geospatial concepts and a shortened version of our core R lesson before progressing into working with
+specialized geospatial packages in R. This workshop gets learners to a fairly advanced stage of creating geospatial plots (i.e. maps of
+data distributions), but does not cover data organisation or cleaning. For a more general workshop covering these topics, please check
 out our [Ecology](#dc-ecology) and [Social Sciences](#dc-socialsci) curricula.
 
 ### <a id="dc-socialsci"></a>Data Carpentry: Social Sciences
 This workshop covers data organisation with spreadsheets, data cleaning with OpenRefine, and some data analysis and plotting with R. This
 workshop is very similar to our [Ecology](#dc-ecology) workshop, but uses a dataset more relevant for social scientists, particularly those working with
-interview data. The data used for this workshop is a set of interview responses from interviews of farmers in two countries in eastern 
-Africa about their agricultural practices and household resources. This workshop uses restricted-response data and does not cover 
+interview data. The data used for this workshop is a set of interview responses from interviews of farmers in two countries in eastern
+Africa about their agricultural practices and household resources. This workshop uses restricted-response data and does not cover
 qualitative data analysis or analysis of free-text responses.
 
 ### <a id="lc"></a>Library Carpentry
-This workshop is intended for people working in libraries and the information sciences. It introduces terms, phrases, and concepts in 
-software development and data science, how to best work with data structures, and use regular expressions in searches. We introduce the 
-Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands. 
-We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we 
-cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version 
+This workshop is intended for people working in libraries and the information sciences. It introduces terms, phrases, and concepts in
+software development and data science, how to best work with data structures, and use regular expressions in searches. We introduce the
+Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands.
+We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we
+cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version
 control to track your work.
 
 ### <a id="swc-all"></a>Software Carpentry (All Workshops)
 All Software Carpentry workshops include an introduction to Bash shell scripting and version control with Git, along with your choice of
 either R or Python. Learners will gain confidence in using the command-line to navigate their file structure and work with files on their
 computer, culminating in writing custom Bash scripts to automate repetitive analyses. They will learn the core concepts of version
-control and be able to implement a simple Git workflow for tracking their own work. Software Carpentry workshops also include your 
+control and be able to implement a simple Git workflow for tracking their own work. Software Carpentry workshops also include your
 choice of one of our R or Python lessons (listed below).
 
 ### <a id="swc-plot-python"></a>Software Carpentry (Plotting and Programming in Python)
-Our more introductory Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
-visualisation in Python, focusing on working with core data structures (including tabular data, not covered in our Programming with 
-Python lesson), using conditionals and loops, writing custom functions, and creating customised plots. As our more introductory Python 
+Our more introductory Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and
+visualisation in Python, focusing on working with core data structures (including tabular data, not covered in our Programming with
+Python lesson), using conditionals and loops, writing custom functions, and creating customised plots. As our more introductory Python
 offering, this workshop also introduces learners to JupyterLab and strategies for getting help. This workshop is appropriate for learners
 with no previous programming experience. For audiences with some experience with Python or other programming languages, we recommend our
 [Programming with Python](#swc-prog-python) lesson.
 
-### <a id="swc-prog-python"></a>Software Carpentry (Programming with Python) 
-Our more advanced Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
-visualisation in Python, focusing on working with core data structures, using conditionals and loops, writing custom functions, and 
-running Python programs from the command line. This is the more advanced of our two Python offerings for Software Carpentry and is 
-appropriate for learners with some previous programming experience, in Python or other languages. For audiences with no previous 
+### <a id="swc-prog-python"></a>Software Carpentry (Programming with Python)
+Our more advanced Python lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and
+visualisation in Python, focusing on working with core data structures, using conditionals and loops, writing custom functions, and
+running Python programs from the command line. This is the more advanced of our two Python offerings for Software Carpentry and is
+appropriate for learners with some previous programming experience, in Python or other languages. For audiences with no previous
 programming experience, we recommend our [Plotting and Programming in Python](#swc-plot-python) lesson.
 
 ### <a id="swc-repro-R"></a>Software Carpentry (R for Reproducible Scientific Analysis)
-Our more introductory R lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and 
-visualisation in R, focusing on working with tabular data and other core data structures, using conditionals and loops, writing custom 
-functions, and creating publication-quality graphics. As our more introductory R offering, this workshop also introduces learners to 
+Our more introductory R lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and
+visualisation in R, focusing on working with tabular data and other core data structures, using conditionals and loops, writing custom
+functions, and creating publication-quality graphics. As our more introductory R offering, this workshop also introduces learners to
 RStudio and strategies for getting help. This workshop is appropriate for learners with no previous programming experience. For audiences
 with some experience with R or other programming languages, we recommend our [Programming with R](#swc-prog-R) lesson.
 
 ### <a id="swc-prog-R"></a>Software Carpentry (Programming with R)
 Our more advanced R lesson. In addition to our [standard content](#swc-all), this workshop covers data analysis and
-visualisation in R focusing on working with core data structures, using conditionals and loops, writing custom functions, and running R 
-programs from the command line. This is the more advanced of our two R offerings for Software Carpentry and is appropriate for learners 
-with some previous programming experience, in R or other languages. For audiences with no previous programming experience, we recommend 
+visualisation in R focusing on working with core data structures, using conditionals and loops, writing custom functions, and running R
+programs from the command line. This is the more advanced of our two R offerings for Software Carpentry and is appropriate for learners
+with some previous programming experience, in R or other languages. For audiences with no previous programming experience, we recommend
 our [R for Reproducible Scientific Analysis](#swc-repro-R) lesson.
 
+### <a id="community-lessons"></a> Community Developed Lessons
+In addition to the established curricula listed above,
+many members of our community work to develop new lesson material
+on a wide range of topics.
+You can see a list of these lessons on our
+[Community Developed Lessons page][community-lessons].
+We hope you find a lesson there that suits your needs and interests.
+These materials exist at varying stages of maturity,
+from only the basics of a lesson outline up to and
+including stable lessons with a full set of exercises and solutions,
+and The Carpentries accepts no responsibility for
+their accuracy or quality.
+The content of most community developed lessons is liable to change at any time.
+Your perspective is a valuable resource to help improve all our lessons!
+If you do learn or teach from any lesson under community development,
+please take the time to provide feedback on your experience to the authors.
+
+[community-lessons]: https://carpentries.org/community-lessons/


### PR DESCRIPTION
to address Issue raised by @lexnederbragt in https://github.com/carpentries-incubator/proposals/issues/48

This PR introduces:

1. a link to the [Community Developed Lessons page](https://carpentries.org/community-lessons/) from the section about contributing to Incubator lesson development in the [Development of Lessons](https://carpentries.org/involved-lessons/)
2. adds a new section mentioning the community lessons and [Community Developed Lessons page](https://carpentries.org/community-lessons/) to the end of [About The Carpentries Curricula](https://carpentries.org/workshops-curricula/)

point 2 may be less easy to merge than point 1, so please let me know if you'd prefer two separate PRs...

(My editor also automatically stripped trailing spaces - sorry for the noisy diff!)