### PR TITLE
fix links between community lesson info & listing by topic 

### DIFF
--- a/pages/community-lessons.md
+++ b/pages/community-lessons.md
@@ -15,14 +15,14 @@ permalink: "/community-lessons/"
   <div itemprop="name">
   <h1>{{ page.title }}</h1>
   </div>
-  
+
   <p class="teaser" itemprop="description">
     {{ page.teaser }}
   </p>
-  
 
-The Carpentries community is commited to a collaborative and open process for lesson development and to sharing teaching materials. We 
-provide two avenues for community members to share lesson materials - **The Carpentries Incubator** and **The CarpentriesLab**. 
+
+The Carpentries community is commited to a collaborative and open process for lesson development and to sharing teaching materials. We
+provide two avenues for community members to share lesson materials - **The Carpentries Incubator** and **The CarpentriesLab**.
 
 [The Carpentries Incubator](#the-carpentries-incubator) is for:
 * Collaborative lesson development (from conceptual to stable lessons).
@@ -32,11 +32,11 @@ provide two avenues for community members to share lesson materials - **The Carp
 * Repository of peer-reviewed, short-format, lessons that use the teaching approach and lesson design from The Carpentries.
 * Getting peer-review on the content of the lesson in the way traditional journal peer-review wouldn’t be able to provide.
 
-People already familiar with The Carpentries teaching practices can teach 
-Carpentries Incubator or CarpentriesLab lessons in meetups, in classes, or as complements to a "standard" 2-day Carpentries workshop. 
+People already familiar with The Carpentries teaching practices can teach
+Carpentries Incubator or CarpentriesLab lessons in meetups, in classes, or as complements to a "standard" 2-day Carpentries workshop.
 These lessons can also be used by independent learners, outside of workshops.
 
-> **Looking for a list of our core lessons?** Follow the links below. 
+> **Looking for a list of our core lessons?** Follow the links below.
 > * [Data Carpentry Core Lessons](https://datacarpentry.org/lessons/)
 > * [Software Carpentry Core Lessons](https://software-carpentry.org/lessons/index.html)
 > * [Library Carpentry Core Lessons](https://librarycarpentry.org/lessons/)
@@ -53,8 +53,8 @@ If you are interested in developing or submitting a lesson to The Carpentries In
 
 The CarpentriesLab is a place for sharing high-quality, peer-reviewed lessons that follow best practices in pedagogy and the general teaching practices used in Carpentries workshops.
 
-Lessons in The CarpentriesLab have been peer-reviewed and are vetted by The Carpentries as high-quality resources. 
-We encourage you to browse the Lab lessons for materials that meet your needs and to use these materials freely (all lessons are 
+Lessons in The CarpentriesLab have been peer-reviewed and are vetted by The Carpentries as high-quality resources.
+We encourage you to browse the Lab lessons for materials that meet your needs and to use these materials freely (all lessons are
 licensed [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)). However, we are unable to offer workshops teaching these lessons upon
 request.
 
@@ -85,7 +85,7 @@ At this time, we are not accepting lesson submissions to The CarpentriesLab. If 
 {% assign lesson_with_tag = site.data.community_lessons | where_exp: "item", "item.lesson_tags contains t" %}
 
 {% for l in lesson_with_tag %}
-- [{{l.description}}](#{{ l.description | slugify: "pretty" }}) <a href="#lessons-in-the-{{l.carpentries_org}}"><span class="{{ l.carpentries_org }} radius label">{{l.carpentries_org}}</span></a>
+- [{{l.description}}](#{{ l.description | slugify }}) <a href="#lessons-in-the-{{l.carpentries_org}}"><span class="{{ l.carpentries_org }} radius label">{{l.carpentries_org}}</span></a>
 {% endfor %}
 {% endfor %}
 
@@ -118,4 +118,3 @@ At this time, we are not accepting lesson submissions to The CarpentriesLab. If 
 </div>
 
 </div>
-


### PR DESCRIPTION
Use `slugify` filter without `pretty` to fix linking from "Lessons by Topic" listing and lessons with special characters (e.g. `()`) in their title. 

**The problem:** linking is broken between "List of Community Developed Lessons by Topic" list and lesson info (under "Lessons in The Carpentries Incubator") for lessons with special characters in their title. For example, see link to "Introduction to Conda for (Data) Scientists" from https://carpentries.org/community-lessons/#conda

**The solution:** removing the `pretty` option from the slugify` filter makes these anchor links work correctly with the headings created for each lesson. Not sure if there's a reason why `pretty` was being used here, though? Will this fix break something else? I tested this locally and it seemed to work alright, but still wanted to check...