### PR TITLE
Document Help Wanted Issues page

### DIFF
--- a/pages/community-lessons.md
+++ b/pages/community-lessons.md
@@ -47,7 +47,7 @@ The Carpentries Incubator is a place for Carpentries community members to share 
 
 Lessons in The Carpentries Incubator are developed and supported by community members and are not officially endorsed by The Carpentries. We encourage you to browse the Incubator lessons for materials that meet your needs and to use these materials freely (all lessons are licensed [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)). However, we are unable to offer workshops teaching these lessons upon request.
 
-If you are interested in developing or submitting a lesson to The Carpentries Incubator, learn how at our [GitHub Repository](https://github.com/carpentries-incubator/proposals#readme).
+If you are interested in developing or submitting a lesson to The Carpentries Incubator, learn how at our [GitHub Repository](https://github.com/carpentries-incubator/proposals#readme). Please read the information on our [Development of Lessons page](/involved-lessons/) if you would like to contribute to the development of a lesson already present in The Carpentries Incubator. You can also find a list of issues in need of attention on the [Help Wanted page](/help-wanted-issues/).
 
 ## The CarpentriesLab
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -136,7 +136,7 @@ The Carpentries community is commited to a collaborative and open process for le
 [The CarpentriesLab](/community-lessons/#the-carpentrieslab) is for sharing peer-reviewed lessons, vetted by the The Carpentries. We are not currently accepting submissions for these lessons.
 
 Those looking for ways to contribute to existing lesson material can find
-a list of issues in need of attention on the [Help Wanted](/help-wanted-issues/) page.
+a list of issues in need of attention on the [Help Wanted page](/help-wanted-issues/).
 
 ### Assessment Network
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -129,12 +129,14 @@ network with other domain experts in The Carpentries community. We are not curre
 
 ### Lesson Developers
 
-The Carpentries community is commited to a collaborative and open process for lesson development and to sharing teaching materials. We provide two avenues for community members to share lesson materials.  
+The Carpentries community is commited to a collaborative and open process for lesson development and to sharing teaching materials. We provide two avenues for community members to share lesson materials.
 
-[The Carpentries Incubator](/community-lessons/#the-carpentries-incubator) is for Carpentries community members to share Carpentries-styel teaching materials at all stages of development, to receive feedback from other community members. These lessons are not officially endorsed by The Carpentries. Read [more information](https://github.com/carpentries-incubator/proposals/blob/master/README.md) about contributing to The Carpentries Incubator.
+[The Carpentries Incubator](/community-lessons/#the-carpentries-incubator) is for Carpentries community members to share Carpentries-style teaching materials at all stages of development, to receive feedback from other community members. These lessons are not officially endorsed by The Carpentries. Read [more information](https://github.com/carpentries-incubator/proposals/blob/master/README.md) about contributing to The Carpentries Incubator.
 
 [The CarpentriesLab](/community-lessons/#the-carpentrieslab) is for sharing peer-reviewed lessons, vetted by the The Carpentries. We are not currently accepting submissions for these lessons.
 
+Those looking for ways to contribute to existing lesson material can find
+a list of issues in need of attention on the [Help Wanted](/help-wanted-issues/) page.
 
 ### Assessment Network
 
@@ -220,7 +222,7 @@ A global CarpentryCon will be held every two years, with locally organised Carpe
 ### Community events
 There are many opportunities to join community meetings, subcommittees
 and debriefing sessions. Find links to them on this <a href="http://pad.software-carpentry.org/pad-of-pads">Etherpad</a>, and subscribe to the calendar below to watch all that is
-going on throughout our community. 
+going on throughout our community.
 
 <div id='calendar' markdown="0">Community Calendar goes here</div>
 

--- a/pages/help-wanted-issues.md
+++ b/pages/help-wanted-issues.md
@@ -18,6 +18,8 @@ permalink: "/help-wanted-issues/"
 {{ page.teaser}}
 </p>
 
+<a href="#for-maintainers">Information for Lesson Maintainers</a>
+
 {% assign help_wanted = site.data.help_wanted_issues %}
 
 {% assign orgs = help_wanted | map: "org_name" | uniq %}
@@ -65,6 +67,22 @@ Updated: <time class="icon-calendar pr20" datetime="{{ i.updated_at | date_to_xm
 {% endfor %}
 {% endfor %}
 
+<h2 id="for-maintainers">Information for Maintainers</h2>
+
+Repositories are included in this page at the maintainers' discretion:
+if you are a maintainer of a lesson from The Carpentries,
+Software Carpentry,
+Data Carpentry,
+Library Carpentry,
+The Carpentries Incubator,
+or CarpentriesLab
+and would like to add your repository to,
+or remove your repository from this listing,
+please send an email to [team@carpentries.org](mailto:team@carpentries.org).
+
+[Read this guide to learn more about how and when to add "help wanted" and other labels to
+issues on your lesson repository][handbook-github-labels].
+
 </div>
 
 <div class="medium-4 column list-tags">
@@ -104,3 +122,7 @@ Updated: <time class="icon-calendar pr20" datetime="{{ i.updated_at | date_to_xm
 </div>
 
 </div>
+
+
+
+[handbook-github-labels]: https://docs.carpentries.org/topic_folders/maintainers/github_labels.html


### PR DESCRIPTION
1. Add some info for maintainers to Help Wanted page
2. Point visitors to Help Wanted page from [Community Developed Lessons](https://carpentries.org/community-lessons/) and [Join Our Community](https://carpentries.org/community/) pages.