### PR TITLE
Update 2020-09-16-apply-feedback-facilitators-cohort.md

### DIFF
--- a/_posts/2020/09/2020-09-16-apply-feedback-facilitators-cohort.md
+++ b/_posts/2020/09/2020-09-16-apply-feedback-facilitators-cohort.md
@@ -29,7 +29,7 @@ With this in mind, we are excited for all the possibilities that equipping commu
 - maintain a public, community-wishlist board that collates community feedback on different initiatives and experiences in The Carpentries
 - recommend topics for Carpentries Conversations and Themed Discussions to the Instructor Development and Communications facilitation team as appropriate
 
-![Feedback facilitation program lifecycle]({{ site.urlimg }}/blog/2020/09/program-lifecycle.png)
+![Feedback facilitation program lifecycle]({{ site.urlimg }}blog/2020/09/program-lifecycle.png)
 _Diagram above shows how feedback facilitators in The Carpentries can expect to spend six months as part of  cohort_
 
 If this sounds like you, we cannot wait to hear from you. [Fill this form](https://forms.gle/mSh6zj7LYvmjFpuS8) to express your interest in joining the first-ever cohort of feedback facilitators in The Carpentries. Applications close at the end of the day, anywhere on Earth on Monday, October 5.


### PR DESCRIPTION
1. The program life-cycle diagram could use improvement in background color / foreground text color / color contrasts.

2. Currently the diagram is invisible due to an HTTP 404 error resulting from an extra slash before "blog" in the URL.

Current URL:
https://carpentries.org/images//blog/2020/09/program-lifecycle.png

Proposed URL:
https://carpentries.org/images/blog/2020/09/program-lifecycle.png


Please find screenshots from Google Chrome and Mozilla Firefox showing that there is no visible diagram at
https://carpentries.org/blog/2020/09/apply-feedback-facilitators-cohort/

![chrome MISSING diagram](https://user-images.githubusercontent.com/3046889/95005912-a6601680-061f-11eb-8d78-521ccb0b305b.JPG)

![firefox MISSING diagram](https://user-images.githubusercontent.com/3046889/95005913-a8c27080-061f-11eb-936e-9af96774ad24.JPG)

