### PR TITLE
Remove trailing slash that stops images showing on the site

### DIFF
--- a/_build_netlify.sh
+++ b/_build_netlify.sh
@@ -14,7 +14,7 @@ cat > _config_netlify.yml <<EOF
 url: 		'$URL'
 baseurl: 	''
 filesurl:       '$URL/files'
-urlimg: 	'$URL/images/'
+urlimg: 	'$URL/images'
 
 # See › https://github.com/jekyll/jekyll-gist#disabling-noscript-support
 gist:

--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ mailing_lists   : "http://carpentries.topicbox.com/groups"
 # Example: <img src="{{ site.urlimg }}{{ post.image.title }}" />
 # Markdown-Example for posts ![Image Text]({{ site.urlimg }}image.jpg)
 #
-urlimg: 'https://carpentries.org/images/'
+urlimg: 'https://carpentries.org/images'
 
 
 # Logo size is 600x80 pixels

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -8,7 +8,7 @@
 url: 		'http://localhost:4000'
 baseurl: 	''
 filesurl:       'http://localhost:4000/files'
-urlimg: 	'http://localhost:4000/images/'
+urlimg: 	'http://localhost:4000/images'
 
 # See › https://github.com/jekyll/jekyll-gist#disabling-noscript-support
 gist:


### PR DESCRIPTION
This little trailing `/` is making that images are not loading on the site, as it fails with `//` one given by the `urlimg` and another provided when the images have been added.