### PR TITLE
Suggest "Core Team" for "Our Team" page

### DIFF
--- a/pages/team.html
+++ b/pages/team.html
@@ -1,6 +1,6 @@
 ---
 layout: page-fullwidth
-title: "Our Team"
+title: "Our Core Team"
 permalink: /team/
 ---
 


### PR DESCRIPTION
We have been asked to define Core Team in our governance documentation for the Trainers Leadership, and in linking to this page I see that there is no indication that this is the group defined as such. Since this is a term we use widely, I think it makes sense to be abundantly clear on this page that this is the "Core Team"

Not sure if this is the right place or the only place for this update.
