### PR TITLE
fix markdown link formatting

### DIFF
--- a/_posts/2021/02/2021-02-08-complete-R-lesson-japanese.md
+++ b/_posts/2021/02/2021-02-08-complete-R-lesson-japanese.md
@@ -100,7 +100,7 @@ We are also interested in training instructors in Japan and holding workshops. P
 if you are able to support this in any way. 
 
 We also actively contribute Japanese terms to the [Glosario](https://glosario.carpentries.org/)
-project and encourage pull requests to the [GitHub repository[(https://github.com/carpentries/glosario).
+project and encourage pull requests to the [glosario GitHub repository](https://github.com/carpentries/glosario).
 
 ### Find Out More
 


### PR DESCRIPTION
This fixes broken formatting of a link in the most recent blog post