### PR TITLE
Adds "Edit on GitHub" link to all pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -163,6 +163,7 @@ defaults:
       # sidebar:    		# Possible values › left, right › by default there will be no sidebar
       comments: false
       author: admin     # Default author for pages
+      edit_on_github: true
   -
     scope:
       path: ""
@@ -172,6 +173,7 @@ defaults:
       # sidebar:        # Possible values › left, right › by default there will be no sidebar
       comments: true
       author: admin     # Default author for posts
+      edit_on_github: true
 
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -163,7 +163,6 @@ defaults:
       # sidebar:    		# Possible values › left, right › by default there will be no sidebar
       comments: false
       author: admin     # Default author for pages
-      edit_on_github: true
   -
     scope:
       path: ""
@@ -173,7 +172,6 @@ defaults:
       # sidebar:        # Possible values › left, right › by default there will be no sidebar
       comments: true
       author: admin     # Default author for posts
-      edit_on_github: true
 
 
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,9 @@ layout: compress
 	{% include _masthead.html %}
 	{{ content }}
 
+        {% if page.edit_on_github  %}
 	{% include _edit_on_github.html %}
+        {% endif %}
 
 	{% unless page.skip_boilerplate %}
 	{% include _footer.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,11 @@ layout: compress
 	{% include _masthead.html %}
 	{{ content }}
 
+	{% include _edit_on_github.html %}
+
 	{% unless page.skip_boilerplate %}
 	{% include _footer.html %}
 	{% endunless %}
-
 	{% include _footer_scripts.html %}
 </body>
 </html>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 format: frontpage
+edit_on_github: false
 ---
 <div id="header-home">
     <div class="row">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,10 +39,6 @@ format: post
 			{{ content }}
 			</div>
 
-                        {% if page.edit_on_github == true %}
-                        {% include _edit_on_github.html %}
-                        {% endif %}
-
 			{% if page.show_meta == true %}
 			{% include _meta_information.html %}
 			{% endif %}

--- a/pages/pages-root-folder/404.md
+++ b/pages/pages-root-folder/404.md
@@ -5,6 +5,7 @@ subheadline: "HTTP 404"
 teaser: "Maybe the webpage was moved or deleted; or did you maybe mistype the link?"
 sitemap: false
 permalink: "/404.html"
+edit_on_github: false
 ---
 ## No problem!
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -42,4 +42,5 @@ permalink: /index.html
 # this page as active in the topbar navigation
 #
 homepage: true
+edit_on_github: false
 ---


### PR DESCRIPTION
Fixes #926 by moving the "Edit on GitHub" link to the default layout.