### PR TITLE
fix formatting that created a table like view

### DIFF
--- a/pages/members.md
+++ b/pages/members.md
@@ -28,7 +28,7 @@ the growth and sustainability of The Carpentries and is building local capacity 
 
 - Columbia University
 - CSIRO
-- Delft University of Technology | 4TU.ResearchData
+- Delft University of Technology - 4TU.ResearchData
 - Helmholtz Information & Data Science Academy (HIDA)
 - National Oceanic and Atmospheric Administration 
 - New England Software Carpentry Library Consortium


### PR DESCRIPTION
A pipe in the member site name created a table like view when interpreted in markdown.  