### PR TITLE
make Toby Curriculum Team Lead

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -20,7 +20,6 @@ people:
 - name: Erin Becker, PhD
   pic: erinbecker
   position: Associate Director
-  lead: Curriculum Team Lead
   jobplan: https://docs.google.com/document/d/1E6-36D6JqtLxnuHRARVulYs8vpQFYfEdGiRcAZZnjfQ/edit
   social:
     - icon: fab fa-twitter
@@ -59,6 +58,7 @@ people:
 - name: Toby Hodges, PhD
   pic: tobyhodges
   position: Curriculum Community Developer
+  lead: Curriculum Team Lead
   social:
     - icon: fab fa-github
       url: https://github.com/tobyhodges


### PR DESCRIPTION
Change Curriculum Team Lead from Erin to @tobyhodges. Please merge June 2nd