### PR TITLE
CoCC recruitment post

### DIFF
--- a/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
+++ b/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
@@ -10,7 +10,7 @@ tags: ["Community", "Code of Conduct"]
 
 The Carpentries are committed to providing a welcoming and supportive environment for all people, and our [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (CoC) is the framework for this commitment. The [Code of Conduct Committee](https://carpentries.org/coc-ctte/) (CoCC) is responsible for managing the Code of Conduct, handling reports of conduct violations, and advocating for the CoC in the community.
 
-The Carpentries Code of Conduct Committee is currently recruiting new members. We seek 3-4 community members who are passionate about ensuring that The Carpentries is a welcoming space, who have time to dedicate to the committee, who bring diversity to the committee, and who (ideally) have experience developing, communicating, and enforcing conduct-related policy.
+The Carpentries Code of Conduct Committee is currently recruiting new members. We seek 3-4 community members who are passionate about ensuring that The Carpentries is a welcoming space, who have time to dedicate to the committee, and who bring diversity to the committee. In addition, it is beneficial, but not necessary, to have previous experience with this kind of work. 
 
 The Code of Conduct Committee will be leading two community calls in June to discuss the CoC, the committee, and answer questions about the open positions. These calls are in two different time zones to accommodate interested community members around the world.
 

--- a/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
+++ b/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 authors: ["Karen Cranston", "Karin Lagesen", "Francois Michonneau", "Malvika Sharan", "Masami Yamaguchi"]
-teaser: "Code of Conduct Committee recruiting new members, attend one of the community calls in June to find out more about how we help to  make The Carpentries a welcoming and supporting environment."
+teaser: "Code of Conduct Committee is recruiting new members. Attend one of our community discussions in June to find out more about how we help make The Carpentries a welcoming and supporting environment."
 title: "Recruiting new members to the Code of Conduct Committee"
 date: 2021-06-09
 time: "00:00:00"

--- a/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
+++ b/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
@@ -1,0 +1,26 @@
+---
+layout: page
+authors: ["Karen Cranston", "Karin Lagesen", "Francois Michonneau", "Malvika Sharan", "Masami Yamaguchi"]
+teaser: "Code of Conduct Committee recruiting new members, attend one of the community calls in June to find out more about how we help to  make The Carpentries a welcoming and supporting environment."
+title: "Recruiting new members to the Code of Conduct Committee"
+date: 2021-06-09
+time: "00:00:00"
+tags: ["Community", "Code of Conduct"]
+---
+
+The Carpentries are committed to providing a welcoming and supportive environment for all people, and our [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) (CoC) is the framework for this commitment. The [Code of Conduct Committee](https://carpentries.org/coc-ctte/) (CoCC) is responsible for managing the Code of Conduct, handling reports of conduct violations, and advocating for the CoC in the community.
+
+The Carpentries Code of Conduct Committee is currently recruiting new members. We seek 3-4 community members who are passionate about ensuring that The Carpentries is a welcoming space, who have time to dedicate to the committee, who bring diversity to the committee, and who (ideally) have experience developing, communicating, and enforcing conduct-related policy.
+
+The Code of Conduct Committee will be leading two community calls in June to discuss the CoC, the committee, and answer questions about the open positions. These calls are in two different time zones to accommodate interested community members around the world.
+
+* Tuesday, June 22, 11AM UTC
+* Tuesday, June 22 8PM UTC
+
+Please see the [Community Discussion etherpad](https://pad.carpentries.org/community-discussions) to sign up.
+
+Interested in being part of the Code of Conduct Committee? Fill out the [application form](https://forms.gle/XRWupgKQaApJa3387).
+
+We will start reviewing applications on July 1.
+
+If you have questions, feel free to contact [Karen Cranston](mailto:karen.cranston@gmail.com), CoCC Governance Chair or [Malvika Sharan](mailto:malvikasharan@gmail.com), CoCC Incident Response Chair.

--- a/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
+++ b/_posts/2021/06/2021-06-09-recruiting-for-coc-committee.md
@@ -15,7 +15,7 @@ The Carpentries Code of Conduct Committee is currently recruiting new members. W
 The Code of Conduct Committee will be leading two community calls in June to discuss the CoC, the committee, and answer questions about the open positions. These calls are in two different time zones to accommodate interested community members around the world.
 
 * Tuesday, June 22, 11AM UTC
-* Tuesday, June 22 8PM UTC
+* Tuesday, June 22, 8PM UTC
 
 Please see the [Community Discussion etherpad](https://pad.carpentries.org/community-discussions) to sign up.
 


### PR DESCRIPTION
Here is a draft blog post for the Code of Conduct Committee recruitment, with information about the community discussions later in June. Needs review from CoC committee: @malvikasharan @fmichonneau @karinlag @masamiy before merge.