### PR TITLE
consistent layout for core team page

### DIFF
--- a/_data/strategic_partners.yml
+++ b/_data/strategic_partners.yml
@@ -2,18 +2,13 @@ people:
   - name: Angelique Trusler, PhD
     pic: angeliquetrusler
     position: Regional Consultant for Southern Africa
-    social:
-      - icon: fab fa-github
-        url: https://github.com/elletjies
-      - icon: fab fa-twitter
-        url: https://twitter.com/AngeliquePhd
-      - icon: fa fa-envelope
-        url: mailto:angelique@carpentries.org
+    email: angelique@carpentries.org
+
+    github: elletjies
+    twitter: AngeliquePhd
+
   - name: Michael Culshaw-Maurer, PhD
     pic: michaelculshawmaurer
     position: Postdoctoral researcher (joint with CyVerse)
-    social:
-      - icon: fab fa-twitter
-        url: https://twitter.com/MCulshawMaurer
-      - icon: fa fa-envelope
-        url: mailto:culshawmaurer@arizona.edu
+    email: MCulshawMaurer
+    twitter: culshawmaurer@arizona.edu

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -7,180 +7,126 @@ people:
   position: Executive Director
   lead: Business Team Lead
   jobplan: https://docs.google.com/document/d/14wwmQyOKHNivu2xTGbfHCXUtXrVzM_lhRPtfpKfGytQ/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/drkariljordan
-    - icon: fab fa-github
-      url: https://github.com/kariljordan
-    - icon: fab fa-linkedin
-      url: https://www.linkedin.com/in/kariljordan/
-    - icon: fa fa-envelope
-      url: mailto:kariljordan@carpentries.org
+  email: kariljordan@carpentries.org
+  github: kariljordan
+  twitter: drkariljordan
+
 
 - name: Erin Becker, PhD
   pic: erinbecker
   position: Associate Director
   jobplan: https://docs.google.com/document/d/1E6-36D6JqtLxnuHRARVulYs8vpQFYfEdGiRcAZZnjfQ/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/ErinSBecker
-    - icon: fab fa-github
-      url: https://github.com/erinbecker
-    - icon: fa fa-envelope
-      url: mailto:ebecker@carpentries.org
+  email: ebecker@carpentries.org
+  github: erinbecker
+  twitter: ErinSBecker
 
 - name: François Michonneau, PhD
   pic: francoismichonneau
   position: Senior Director of Technology
   lead: Infrastructure Team Lead
   jobplan: https://docs.google.com/document/d/1Y66RlED6a9TN1XxHZF-htJVMZ0dfmqtysFLyXSP8sk4/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/fmic_
-    - icon: fab fa-github
-      url: https://github.com/fmichonneau
-    - icon: fa fa-envelope
-      url: mailto:francois@carpentries.org
-
+  email: francois@carpentries.org
+  github: fmichonneau
+  twitter: fmic_
 
 - name: Zhian N. Kamvar, PhD
   pic: zhiankamvar
   position: Lesson Infrastructure Technology Developer
-  social:
-    - icon: fab fa-github
-      url: https://github.com/zkamvar
-    - icon: fab fa-twitter
-      url: https://twitter.com/zkamvar
-    - icon: fa fa-envelope
-      url: mailto:zkamvar@carpentries.org
+  email: zkamvar@carpentries.org
+  github: zkamvar
+  twitter: zkamvar
 
 
 - name: Toby Hodges, PhD
   pic: tobyhodges
   position: Curriculum Community Developer
   lead: Curriculum Team Lead
-  social:
-    - icon: fab fa-github
-      url: https://github.com/tobyhodges
-    - icon: fab fa-twitter
-      url: https://twitter.com/tbyhdgs
-    - icon: fa fa-envelope
-      url: mailto:tobyhodges@carpentries.org
-      
+  email: tobyhodges@carpentries.org
+  github: tobyhodges
+  twitter: tbyhdgs
+     
 
 - name: Talisha Sutton-Kennedy
   pic: talishasuttonkennedy
   position: Operations Manager
   jobplan: https://docs.google.com/document/d/1Hza2oLS8iC-8k8niwpNVOcbxHsrwZOrYSDak2hmIQfw/edit
-  social:
-    - icon: fab fa-github
-      url: https://github.com/talishask
-    - icon: fa fa-envelope
-      url: mailto:talishask@carpentries.org
-
+  email: talishask@carpentries.org
+  github: talishask
+ 
 - name: SherAaron Hurt
   pic: sheraaronhurt
   position: Deputy Director of Workshops and Meetings
   lead: Workshops Team Lead
   jobplan: https://docs.google.com/document/d/1Rrnzs-fPlvL0Tuw0stWg8DVgJa8SEKJM7b-Kb_6F6m4/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/SherAaronHurt
-    - icon: fab fa-github
-      url: https://github.com/sheraaronhurt
-    - icon: fa fa-envelope
-      url: mailto:sheraaron@carpentries.org
+  email:  sheraaron@carpentries.org
+  github: sheraaronhurt
+  twitter: SherAaronHurt
+
 
 - name: Serah Njambi Rono
   pic: serahnjambirono
   position: Director of Community Development and Engagement
   jobplan: https://docs.google.com/document/d/12EpzCMdKrh9o7WyJR5Xl4u7Hi7PMUc2t5qvvGMhxbBs/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/serahrono
-    - icon: fab fa-github
-      url: https://github.com/serahrono
-    - icon: fab fa-linkedin
-      url: https://www.linkedin.com/in/serahrono/
-    - icon: fa fa-envelope
-      url: mailto:serah@carpentries.org
+  email: serah@carpentries.org
+  linkedin: serahrono
+  twitter: serahrono
+  github: serahrono
 
 - name: Omar Khan
   pic: omarkhan
   position: Communications Manager
-  social:
-    - icon: fab fa-github
-      url: https://github.com/kmomar
-    - icon: fa fa-envelope
-      url: mailto:okhan@carpentries.org
+  email: okhan@carpentries.org
+  github: kmomar
 
 - name: Maneesha Sane
   pic: maneeshasane
   position: Quality Assurance Manager
   jobplan: https://docs.google.com/document/d/1vzvRaH-ilaAdkzk3LZCMvBsBYlokX_5mU5aA7Wvo9PQ/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/maneeshasane
-    - icon: fab fa-github
-      url: https://github.com/maneesha
-    - icon: fa fa-envelope
-      url: mailto:maneesha@carpentries.org
+  email: maneesha@carpentries.org
+  github: maneesha
+  twitter: maneeshasane
+
 
 - name: Kelly Barnes, PhD
   pic: kellybarnes
   position: Deputy Director of Instructor Training
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/kbarne2
-    - icon: fab fa-github
-      url: https://github.com/klbarnes20
-    - icon: fab fa-linkedin
-      url: https://www.linkedin.com/in/klbarnes20/
-    - icon: fa fa-envelope
-      url: mailto:kbarnes@carpentries.org
+  email: kbarnes@carpentries.org
+  github: klbarnes20
+  linkedin: klbarnes20
+  twitter: kbarne2
+
 
 - name: Karen Word, PhD      
   pic: karenword
   position: Director of Instructor Training
   lead: Instructor Training Team Lead
   jobplan: https://docs.google.com/document/d/1l-5DV7-NvJLg60lCjNVabXmRGXFJ-oll3x1IbdZvK0c/edit
-  social:
-    - icon: fab fa-twitter
-      url: https://twitter.com/karen_word
-    - icon: fab fa-github
-      url: https://github.com/karenword
-    - icon: fa fa-envelope
-      url: mailto:krword@carpentries.org
+  email: krword@carpentries.org
+  github: karenword
+  twitter: karen_word
+
 
 - name: Danielle Sieh
   pic: daniellesieh
   position: Workshop Administrator
-  social:
-    - icon: fab fa-github
-      url: https://github.com/danielle06
-    - icon: fa fa-envelope
-      url: mailto:danielle@carpentries.org
+  github: danielle06
+  email: danielle@carpentries.org
+
 
 - name: Alycia Crall, PhD
   pic: alyciacrall
   position: Director of Community
   lead: Community Development Team Lead
-  social:
-    - icon: fa fa-envelope
-      url: mailto:alycia@carpentries.org
-    - icon: fab fa-github
-      url: https://github.com/acrall
-    - icon: fab fa-twitter
-      url: https://twitter.com/alycrall
-    - icon: fab fa-linkedin
-      url: https://www.linkedin.com/in/alycia-crall-5a842646/
+  email: alycia@carpentries.org
+  github: acrall
+  linkedin: alycia-crall-5a842646
+  twitter: alycrall
+
 
 - name: Al Obayuwana
   pic: alobayuwana
   position: Director of Partnerships
   lead: Membership Team Lead
-  social:
-    - icon: fa fa-envelope
-      url: mailto:alobayuwana@carpentries.org
-    - icon: fab fa-github
-      url: https://github.com/Al-Obayuwana
+  email: alobayuwana@carpentries.org
+  github: Al-Obayuwana
+

--- a/_includes/_team_profile.html
+++ b/_includes/_team_profile.html
@@ -36,13 +36,16 @@
 {% endif %}
 </p>
 <ul class="list-inline social-buttons">
-{% for network in member.social %}
-<li>
-<a href="{{ network.url }}">
-<i class="{{ network.icon }}"></i>
-</a>
-</li>
-{% endfor %}
+  <li><a href="mailto:{{ member.email }}"> <i class="fa fa-envelope"></i> </a> </li>
+
+  {% if member.github %}<li> <a href="https://github.com/{{ member.github }}"> <i class="fab fa-github"></i> </a> </li> {% endif %}
+
+  {% if member.linkedin %}<li> <a href="https://linkedin.com/in/{{ member.linkedin }}"> <i class="fab fa-linkedin"></i> </a> </li>  {% endif %}
+
+  {% if member.orcid %}<li> <a href="https://orcid.org/{{ member.orcid }}"> <i class="fab fa-orcid"></i> </a> </li>  {% endif %}
+
+  {% if member.twitter %}<li> <a href="https://twitter.com/{{ member.twitter }}"> <i class="fab fa-twitter"></i> </a> </li> {% endif %}
+
 </ul>
 </div>
 </div>

--- a/_includes/_team_profile.html
+++ b/_includes/_team_profile.html
@@ -21,31 +21,31 @@
   {% assign last_row_item = "" %}
 {% endif %}
 
-                {% if loopindex == 1 %}
-                <div class="row align-center">
-                {% endif %}
-                <div class="medium-4 columns{{ row_align }}{{ last_row_item }}">
-                    <div class="team-member">
-                        <img src="{{ site.filesurl }}/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="">
-                        <h4>{{ member.name }}</h4>
-                        <p class="text-muted">
-                            {{ member.position }}<br>
+{% if loopindex == 1 %}
+<div class="row align-center">
+{% endif %}
+<div class="medium-4 columns{{ row_align }}{{ last_row_item }}">
+<div class="team-member">
+<img src="{{ site.filesurl }}/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="">
+<h4>{{ member.name }}</h4>
+<p class="text-muted">
+{{ member.position }}<br>
 
-                            {% if member.lead %}
-                                <i>{{ member.lead }}</i><br>
-                            {% endif %}
-                        </p>
-                        <ul class="list-inline social-buttons">
-                            {% for network in member.social %}
-                            <li>
-                                <a href="{{ network.url }}">
-                                    <i class="{{ network.icon }}"></i>
-                                </a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                {% if loopindex == 0 %}
-                  </div>
-                {% endif %}
+{% if member.lead %}
+<i>{{ member.lead }}</i><br>
+{% endif %}
+</p>
+<ul class="list-inline social-buttons">
+{% for network in member.social %}
+<li>
+<a href="{{ network.url }}">
+<i class="{{ network.icon }}"></i>
+</a>
+</li>
+{% endfor %}
+</ul>
+</div>
+</div>
+{% if loopindex == 0 %}
+</div>
+{% endif %}


### PR DESCRIPTION
This PR moves the links and layout for the [core team page](https://carpentries.org/team/) to `_includes/_team_profile.html`.  This keeps the links and layout in the `html` page and keeps only the social media ids/email addresses in the yml file, removing the redundant links in each profile and ensuring the layout is consistent for each profile.