### PR TITLE
Correction of community space info for Nordics

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -263,7 +263,6 @@ Here are details about The Carpentries Instructor community in Australia and New
 
 Here are details about The Carpentries Instructor community in the Nordics:
 
-* [Join Carpentries Nordics on Slack](https://swcarpentry.slack.com/archives/CH9MDCTSM)
 * [Join mailing list](https://carpentries.topicbox.com/groups/local-nordic)
 * [Contact](mailto:local-nordic@lists.carpentries.org)
 * [Carpentries Nordics CodiMD](https://codimd.carpentries.org/nordic-community-call)

--- a/pages/community.md
+++ b/pages/community.md
@@ -264,8 +264,9 @@ Here are details about The Carpentries Instructor community in Australia and New
 Here are details about The Carpentries Instructor community in the Nordics:
 
 * [Join mailing list](https://carpentries.topicbox.com/groups/local-nordic)
+* [Join in monthly calls for Carpentries Nordics](https://codimd.carpentries.org/nordic-community-call)
+* [Join CodeRefinery Zulip chat](https://coderefinery.zulipchat.com/#) where many Carpentries community members in Nordics and around are actively discussing. 
 * [Contact](mailto:local-nordic@lists.carpentries.org)
-* [Carpentries Nordics CodiMD](https://codimd.carpentries.org/nordic-community-call)
 
 
 #### Carpentries in Japan
@@ -273,7 +274,7 @@ Here are details about The Carpentries Instructor community in the Nordics:
 Here are details about The Carpentries Instructor community in the Nordics:
 
 * [Activities and collaborative work on GitHub](https://github.com/swcarpentry-ja)
-* Join Carpentries Japan on Slack - English](https://carpentries-jp-en.herokuapp.com/)
+* [Join Carpentries Japan on Slack - English](https://carpentries-jp-en.herokuapp.com/)
 * [Join Carpentries Japan on Slack - 日本語](https://carpentries-ja.herokuapp.com/)
 * [Carpentries Japan on Twitter](https://twitter.com/swcarpentry_ja)
 


### PR DESCRIPTION
The link to Slack channel given as one for Nordic was actually a link to NZ/AU Slack channel, so I removed it.
There is [a channel for Swedish local community](https://swcarpentry.slack.com/archives/CNML4H8QG), but at the moment there has not been high interest in making a Nordic region channel in the community. It seems that Swedish channel is not super active, so I would ask the channel if there is an interest in linking it to this page first before adding it to this page.

For the Nordic chat space, we would rather love to introduce [CodeRefinery Zulip chat forum](https://coderefinery.zulipchat.com/#) where many of the Carpentries community members in Nordic ++ are very actively participating and discussing quite relevant topics to the Carpentries (especially relevant to SWC). 

Regarding the CodiMD, we use it basically only for the monthly community calls, so I edited the description.