### PR TITLE
use camel case for the hashtag

### DIFF
--- a/_posts/2021/11/2021-11-24-carpentries-gratitudes-2021.md
+++ b/_posts/2021/11/2021-11-24-carpentries-gratitudes-2021.md
@@ -16,7 +16,7 @@ The Core Team will be joining you and sharing our green stickies and appreciatio
 ## How to Share Your Gratitudes
 
 Please either share:
-- Directly on Twitter with the hashtag #carpentriesgratitude
+- Directly on Twitter with the hashtag #CarpentriesGratitude
 - Add a comment to [this GitHub issue](https://github.com/carpentries/conversations/issues/29)
 - Send your gratitude to [community@carpentries.org](mailto:community@carpentries.org) and we will share on your behalf, anonymously or with your name attached.
 


### PR DESCRIPTION
Using camel case for hashtags allow screen readers to read them properly.
