### PR TITLE
Adding the Trainer Leadership Committee to the list of Committees and Task Forces

### DIFF
--- a/pages/committees.md
+++ b/pages/committees.md
@@ -13,3 +13,4 @@ infrastructure, and more. Visit the page for each committee or task force to fin
 - [Code of Conduct Committee](https://carpentries.org/coc-ctte/)
 - [Instructor Development Committee](https://carpentries.org/inst-dev/)
 - [Lesson Infrastructure Committee](https://carpentries.org/lesson-infra/)
+- [Trainer Leadership Committee](https://github.com/carpentries/trainers/blob/main/governance.md)


### PR DESCRIPTION
Added the Trainer Leadership Committee to the list of Committees and Task Forces.

Edit: I may have rushed here, the Trainer Leadership Committee is not official yet.