### PR TITLE
add two missing CAC members

### DIFF
--- a/_data/curriculum_advisors.yml
+++ b/_data/curriculum_advisors.yml
@@ -58,6 +58,11 @@
   github: jasonwilliamsny
   curriculum: genomics
   position: member
+  
+- name: Jeff Hollister
+  github: jhollist
+  curriculum: geospatial
+  position: chair
 
 - name: Ming Tang
   github: crazyhottommy
@@ -143,3 +148,8 @@
   github: richmccue
   curriculum: software
   position: member
+  
+- name: Stephen Appel
+  github: srappel
+  curriculum: geospatial
+  position: chair

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -84,8 +84,6 @@
     url: "/core-team-projects/"
   - title: "Community Overview"
     url: "/community/"
-  - title: "Our Curriculum Advisors"
-    url: "/curriculum-advisors/"
   - title: "Our Instructors"
     url: "/instructors/"
   - title: "Our Maintainers"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -84,6 +84,8 @@
     url: "/core-team-projects/"
   - title: "Community Overview"
     url: "/community/"
+  - title: "Our Curriculum Advisors"
+    url: "/curriculum-advisors/"
   - title: "Our Instructors"
     url: "/instructors/"
   - title: "Our Maintainers"


### PR DESCRIPTION
Stephen Appel and Jeff Hollister didn't appear because they were listed as "co-chairs", which didn't parse. Updated to show them both as "chair".
