### PR TITLE
Rename newsletter

### DIFF
--- a/_includes/mailchimp_short_form.html
+++ b/_includes/mailchimp_short_form.html
@@ -1,12 +1,12 @@
 <div markdown="0">
   <div class="row">
     <div class="medium-12 columns">
-      <h2>Subscribe to our Newsletter "Carpentry Clippings"</h2>
+      <h2>Subscribe to our <a href="#"></a>Newsletter "Carpentries Clippings"</a></h2>
       <!-- Begin MailChimp Signup Form -->
       <div id="mc_embed_signup">
         <form action="https://carpentries.us14.list-manage.com/subscribe/post?u=46d7513c798c6bd41e5f58f4a&amp;id=50c3e6d6fe" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
           <div id="mc_embed_signup_scroll">
-	    <label for="mce-EMAIL">Events, Community Updates, Teaching Tips, in your inbox, twice a month</label>
+	    <label for="mce-EMAIL">Events, community updates, and teaching tips in your inbox, twice a month.  <a href="{% link pages/newsletter.html %}">View our newsletter archives.</a> </label>
 	    <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
 
             <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups -->
@@ -15,6 +15,7 @@
             <div class="clear"><input type="submit" value="Subscribe!" name="subscribe" id="mc-embedded-subscribe" class="button" style="background-color: #071159;"></div>
           </div>
         </form>
+        
       </div>
       <!--End mc_embed_signup-->
     </div>

--- a/pages/about.md
+++ b/pages/about.md
@@ -52,7 +52,7 @@ through our [Carpentries Twitter](https://twitter.com/thecarpentries) account.
 Organisations are encouraged to <a href="{{site.url}}/membership/">join us as contributing members to support the work we do.</a> We 
 welcome <a href="{{site.url}}/volunteer/">new people</a> to our community. We have 
 <a href="{{site.url}}/volunteer/">many ways to engage</a>, including The Carpentries <a href="https://twitter.com/thecarpentries">Twitter</a> feed, our <a href="https://swc-slack-invite.herokuapp.com/">Slack</a> channel, 
-subscribing to <em>Carpentry Clippings</em>, our twice-monthly <a href="{{site.url}}/newsletter/">newsletter</a>, following our [Facebook](https://www.facebook.com/carpentries/) page, and by joining some of our <a href="https://carpentries.topicbox.com/groups">email lists</a>.
+subscribing to <em>Carpentries Clippings</em>, our twice-monthly <a href="{{site.url}}/newsletter/">newsletter</a>, following our [Facebook](https://www.facebook.com/carpentries/) page, and by joining some of our <a href="https://carpentries.topicbox.com/groups">email lists</a>.
 
 We announce a lot of what we do via our Twitter feed. [Follow us on Twitter](https://twitter.com/thecarpentries). 
 

--- a/pages/governance.md
+++ b/pages/governance.md
@@ -12,7 +12,7 @@ The Carpentries Executive Council is the highest leadership body of The Carpentr
 
 ## What is the Executive Council working on?
 
-In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentry Clippings](https://carpentries.org/newsletter/) (the organizational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
+In addition to [publicly posting meeting minutes](https://github.com/carpentries/executive-council-info/tree/master/minutes), the Executive Council reports on its activities periodically in [Carpentries Clippings](https://carpentries.org/newsletter/) (the organizational newsletter) as well as through [blog posts](https://carpentries.org/posts-by-tags/#blog-tag-governance).
 The council also prepares [Yearly Summaries](https://github.com/carpentries/executive-council-info/tree/master/year-in-review) of its activities.
 
 ## Executive Council Members

--- a/pages/newsletter.html
+++ b/pages/newsletter.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Our Newsletter, Carpentry Clippings"
+title: "Our Newsletter, Carpentries Clippings"
 permalink: /newsletter/
 ---
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -21,7 +21,7 @@ widget3:
   title: "Get involved"
   url: 'https://carpentries.org/join/'
   icon: 'fas fa-comment-dots'
-  text: 'See all the <a href="/volunteer/">ways you can engage</a> with The Carpentries. Get information about upcoming events such as workshops, meetups, and discussions from our <a href="/community/#community-events">community calendar</a>, or from our twice-monthly <a href="/newsletter/">newsletter</a>, <em>Carpentry Clippings</em>. Follow us on <a href="https://twitter.com/thecarpentries/">Twitter</a>, <a href="https://www.facebook.com/carpentries">Facebook</a>, and <a href="https://swc-slack-invite.herokuapp.com/">Slack</a>.'
+  text: 'See all the <a href="/volunteer/">ways you can engage</a> with The Carpentries. Get information about upcoming events such as workshops, meetups, and discussions from our <a href="/community/#community-events">community calendar</a>, or from our twice-monthly <a href="/newsletter/">newsletter</a>, <em>Carpentries Clippings</em>. Follow us on <a href="https://twitter.com/thecarpentries/">Twitter</a>, <a href="https://www.facebook.com/carpentries">Facebook</a>, and <a href="https://swc-slack-invite.herokuapp.com/">Slack</a>.'
 #
 # Use the call for action to show a button on the frontpage
 #

--- a/pages/welcome-tip-sheet.md
+++ b/pages/welcome-tip-sheet.md
@@ -25,7 +25,7 @@ Glad you asked! [The Carpentries](https://carpentries.org/about/) is an organisa
 The Carpentries supports communications from our Core Team and across our community members in several ways. Worried about too many communications? Don’t be! Only subscribe to the communications you want, and you can unsubscribe at any time.
 
 - [Email Listservs](https://carpentries.topicbox.com/latest): Browse the various options and sign up to receive relevant regional and global communications. We recommend the “Discuss” listserv, which is used for general discussion, but you can find information on [other available listservs](https://docs.carpentries.org/topic_folders/communications/tools/slack-and-email.html).
-- [Newsletter](https://carpentries.org/newsletter/): Carpentry Clippings is published every two weeks and includes community news and relevant job postings.
+- [Newsletter](https://carpentries.org/newsletter/): Carpentries Clippings is published every two weeks and includes community news and relevant job postings.
 - [Carpentries Philanthropy](https://carpentries.us14.list-manage.com/subscribe?u=46d7513c798c6bd41e5f58f4a&id=33f76196ac): Receive communications about the philanthropic work of our organisation.
 - Social media: Follow our organisation’s activities on [Twitter](https://twitter.com/thecarpentries), [Facebook](https://www.facebook.com/carpentries), [LinkedIn](https://www.linkedin.com/company/the-carpentries/), and [YouTube](https://www.youtube.com/c/TheCarpentries).
 


### PR DESCRIPTION
- Fixes references to "Carpentry Clippings" >> "Carpentries Clippings"
- Adds archive link to front page