### PR TITLE
Join page updates

### DIFF
--- a/pages/join.md
+++ b/pages/join.md
@@ -23,12 +23,3 @@ Organisations can support The Carpentries by [making a donation]({{site.fundrais
 ### Pathways for Engagement - Individuals
   
 Individuals have many ways to get involved. See our [community page]({{site.url}}/community/). Individuals can also support The Carpentries by [making a donation]({{site.fundraising_link}}).
-
-#### Share Your Knowledge
-
-- <a href="https://carpentries.typeform.com/to/BK55ld">Blog for us</a> about a workshop, event, or insight.
-- Share information <a href="https://docs.google.com/forms/d/e/1FAIpQLSeiu5NzJsLxYueaQrNn_qKbaa5JR2Sz12CeCRyedKQxwb54Dw/viewform">about your favourite tool</a>.
-
-  
-
-

--- a/pages/join.md
+++ b/pages/join.md
@@ -16,16 +16,13 @@ The Carpentries by becoming a <a href="{% link pages/membership.html %}">Member 
 
 #### Become a Sponsor
 
-Organisations and individuals can support The Carpentries by [donating]({{site.fundraising_link}}) or becoming a Sponsoring organisation. If you are interested in being a Corporate Sponsor, please [get in touch](mailto:{{site.sponsorship_contact}})!
-
-
-
+Organisations can support The Carpentries by [making a donation]({{site.fundraising_link}}) or becoming a Sponsoring organisation. Read more about our [sponsorship program]({% link pages/sponsorship.md %}).
   
 <hr>
 
 ### Pathways for Engagement - Individuals
   
-Individuals have many ways to get involved. See our [community page]({{site.url}}/community/).
+Individuals have many ways to get involved. See our [community page]({{site.url}}/community/). Individuals can also support The Carpentries by [making a donation]({{site.fundraising_link}}).
 
 #### Share Your Knowledge
 


### PR DESCRIPTION
On the [join page](https://carpentries.org/join/) this directs organizations to the sponsorship page and removes the forms for individuals to submit a blog post. 

This addresses #1338 and #1339 