### PR TITLE
CarpentryCon info

### DIFF
--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -2,7 +2,7 @@
 layout: page-fullwidth
 title: "The CarpentryCon Task Force"
 permalink: /carp-con-tf/
-excerpt: The CarpentryCon Task Force mission organises a meeting to bring together members of the global Carpentries community.
+excerpt: The goal of the CarpentryCon Task Force is to organise a biennual conference to bring together members of the global Carpentries community and others who share our core values.
 ---
 
 

--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -8,7 +8,7 @@ excerpt: The goal of the CarpentryCon Task Force is to organise a biennual confe
 
 ## What is CarpentryCon?
 
-CarpentryCon is the key biennial community-building and networking event in The Carpentries' calendar of activities. This event brings together newer and more experienced community members to share knowledge, to network, to develop new skills, and to develop strategies for building strong local communities.  The CarpentryCon Task Force's mission is to organise and host this event, whether in-person or online. 
+CarpentryCon is the key biennial community-building and networking event in The Carpentries' calendar of activities. This event brings together newer and more experienced community members to share knowledge, to network, to develop new skills, and to develop strategies for building strong local communities.  The CarpentryCon Task Force's goal is to organise and host this event, whether in-person or online. 
 
 ## Upcoming and previous events
 

--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -18,5 +18,5 @@ CarpentryCon is the key biennial community-building and networking event in The 
 
 ## Contacting the Task Force
 
-You can email the Task Force at [email us](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/). 
+You can email the Task Force at [{{site.carpentrycon_contact}}](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/). 
 

--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -18,5 +18,5 @@ CarpentryCon is the key biennial community-building and networking event in The 
 
 ## Contacting the Task Force
 
-You can email the Task Force at [{{site.carpentrycon_contact}}](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/). 
+You can email the Task Force at [{{site.carpentrycon_contact}}](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/) or follow the event on [Twitter](https://twitter.com/CarpentryCon). 
 

--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -5,78 +5,18 @@ permalink: /carp-con-tf/
 excerpt: The CarpentryCon Task Force mission organises a meeting to bring together members of the global Carpentries community.
 ---
 
-The CarpentryCon Task Force mission is to organise and host a meeting every two years to bring together members of the global Carpentries community and people with similar interests. 
 
-**_Our Goal:_**       
-To organise an event that will bring together and skill up members of the global Carpentries community and people with similar interests.
+## What is CarpentryCon?
 
-**_Our Approach:_**    
-Starting approximately nine months before the next scheduled conference dates, the Task Force holds monthly meetings. At the moment, we are planning a virtual CarpentryCon in 2022. We are currently seeking volunteers to [join the Task Force](https://docs.google.com/forms/d/e/1FAIpQLSex5YLDI6RA_KFeenPzW6Tsy3A0fUcCZLXtCxWlYuY4qhm6oA/viewform?usp=sf_link).
+CarpentryCon is the key biennial community-building and networking event in The Carpentries' calendar of activities. This event brings together newer and more experienced community members to share knowledge, to network, to develop new skills, and to develop strategies for building strong local communities.  The CarpentryCon Task Force's mission is to organise and host this event, whether in-person or online. 
 
-**_Our Structure:_**       
-The Task Force has monthly meetings, which are open to new members. 
+## Upcoming and previous events
 
-### 2020 CarpentryCon Task Force Membership
-
-[This organisers page on the CarpentryCon 2020 website](https://2020.carpentrycon.org/task-force/) lists community members who helped organise for an in-person conference, as well as those that stepped up to help organise a virtual edition of the conference due to COVID-19 restrictions.
-
-**_Leadership:_**    
-Christina Koch and Daniel Ouso were co-chairs of the 2020 CarpentryCon Task Force.
-
-**_Virtual Conference Organisers:_**
-
-- Jesse Lambertson
-- Sara El-Gebali
-- Mike Trizna
-- Jason Williams
-- Malvika Sharan
-- Mateusz Kuzak
-- Dan Kerchner
-
-**_Pre-Pandemic In-Person Conference Organisers:_**
-
-- Bianca Peterson 
-- Silvia Di Giorgio  
-- Anne Fouilloux 
-- Jessica Upani 
-- Gabriel Salubi 
-- Sateesh Peri 
-- Sarah Stevens 
-- Mina Zamani 
-- Marco Chiapello 
-- Aleksandra Nenadic
-- Shaily Gandhi 
-- Rohit Goswami 
-- Elizabeth Wickes 
-- Cody Hennesy 
-- Jesse A Lambertson
-- Dan Kerchner
-
-**_Core Team Liasons:_**
-
-- Sher! Hurt 
-- Serah Rono
-- Omar Khan
-- Elizabeth Williams
-
-[Here is the 2020 CarpentryCon Task Force etherpad](https://pad.carpentries.org/2020carpentrycontaskforce). It holds all meeting notes and agenda items. A copy of these nots can be found in the [CarpentryCon repository on GitHub](https://github.com/carpentries/carpentrycon).
-
-### 2018 CarpentryCon Task Force Membership
-
-In 2018, the following Task Force members were responsible for [a very successful inaugural CarpentryCon](https://2018.carpentrycon.org/). 
-
-- Fotis Psomopoulos (Co-chair): Visa support, accommodation, childcare
-- Malvika Sharan (Co-chair): Visa support, travel scholarships, on-campus accommodation, diversity and inclusion
-- Belinda Weaver (The Carpentries): Website, sponsorship, abstract submissions, news and announcements
-- SherAaron Hurt (The Carpentries): Travel scholarships, sponsorship, childcare, diversity and inclusion, registration
-- Mark Laufersweiler: on-site speaker/facilitator organizer, where needed
-- Danielle Quinn: Social media
-- Ivo Arrey: on site volunteer coordination
-
-[Here is the 2018 CarpentryCon Task Force etherpad](https://pad.carpentries.org/2018carpentrycontaskforce). It holds all meeting notes and agenda items.
-
+* [CarpentryCon 2022](https://2022.carpentrycon.org/) (Virtual)
+* [CarpentryCon 2020](https://2020.carpentrycon.org/) (Virtual)
+* [CarpentryCon 2018](https://2018.carpentrycon.org/) (Dublin, Ireland)
 
 ## Contacting the Task Force
 
-We are now recruiting new Task Force members to help us organise CarpentryCon 2022. If you are interested in getting involved, [email us](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/). 
+You can email the Task Force at [email us](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack](https://swc-slack-invite.herokuapp.com/). 
 


### PR DESCRIPTION
Fixes #1340  by removing redundant (and consequently often outdated or incorrect) information on the CarpentryCon Task Force page.  