### PR TITLE
Member council

### DIFF
--- a/pages/member_faq.md
+++ b/pages/member_faq.md
@@ -4,56 +4,57 @@ title: "FAQ For Member Organisations"
 permalink: /member_faq/
 ---
 
-- [Memberships](#memberships)
-- [Workshops](#technical-workshops)
-- [Instructor Training](#instructor-training-workshops)
-- [Contact us](#contact-us)
-
+<div class="panel radius" markdown="1">
+**Table of Contents**
+{: #toc }
+*  TOC
+{:toc}
+</div>
 
 ## Memberships
 
-1. **What are the standard membership packages you offer?**<br>
+### What are the standard membership packages you offer?
 We offer Bronze, Silver, and Gold membership packages, each with an allotted number of Centrally-Organised [workshops](/workshops). 
 Silver and Gold memberships also include seats in our [Instructor Training](https://carpentries.github.io/instructor-training/) 
 program. Platinum memberships include Instructor Training seats, but no Centrally-Organised workshops. All memberships include unlimited 
 self-organised workshops and access to Member pricing for additional Centrally-Organised workshops and Instructor Training seats purchased during the membership year. Read more about the benefits and dues for each plan on our [membership](/membership) page. 
 
-2. **Which membership should I purchase?**<br>
+### Which membership should I purchase?
 * Bronze membership is an excellent option for any organisation starting out with The Carpentries and wanting to quickly bring data and computational training to their community. The Bronze level is also great for introducing your local community to The Carpentries and building interest for instructor training.
 * Silver and Gold memberships are ideal for organisations wanting to quickly build capacity for training in their community. 
 * Platinum memberships are best for organisations that would like to continue building capacity for training and already have a group of local Carpentries Instructors capable of running Self-Organised workshops. 
 * Titanium memberships are suited for organisations who do not need coordinated workshops or Instructor Training seats but would 
 like to maintain their membership status, financially support The Carpentries, and connect with other Members. To be eligible for 
 Titanium membership, organisations must have at least one prior year of membership.<br><br>
-3. **What if those membership packages do not fit my institution’s needs?**<br>
+
+### What if those membership packages do not fit my institution’s needs?
 We would be happy to talk with you to learn more about your institution’s goals and create a custom plan that works for you.  Contact our membership team to schedule a meeting at [{{site.membership_contact}}](mailto:{{site.membership_contact}}).
 
-4. **Do I need to renew my membership each year?**<br>
+### Do I need to renew my membership each year?
 Yes. The Carpentries memberships are annual memberships, extending for a period of one year. Renewing your membership in advance is a great way to avoid a lapse in membership. 
 
-5. **What if I don't use all of my membership benefits?**<br>
+### What if I don't use all of my membership benefits?
 We encourage you to use all of your benefits during your membership term. If there are unused benefits at the end of your membership term, and you 
 are renewing, we will roll over 50% of unused benefits (rounded up) to your new membership term, on request.  
 
-6. **Is financial support available?**<br>
+### Is financial support available?
 Yes - organisations with financial need are encouraged to 
 [apply for financial support](https://carpentries.typeform.com/to/lZat2eO5). Financial support is available for Bronze, Silver, 
 and Gold memberships only, and is subject to availability. Organisations awarded financial support may receive support between 
 25% - 50% of their tiered price.
 
-7. **Are any other discounts available?**<br>
+### Are any other discounts available?
 Organisations supporting [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html), who engage in
 service activities to teach and support newly trained Instructors across our global community, are eligible for a discount to their membership fee 
 equivalent to six (6) seats in Instructor Training per active Instructor Trainer. This discount is available at any membership level. 
 
-8. **How can I find out if my institution already has a membership?**<br>
+### How can I find out if my institution already has a membership?
 A list of our [current Member organisations](https://carpentries.org/members/) can be found on our website. If you would like 
 help in making contact with the person in charge of your institutional membership, email [{{site.membership_contact}}](mailto:{{site.membership_contact}}).
 
-
 ## Workshops
 
-1. **How do your workshops run?**<br>
+### How do your workshops run?
 For [Centrally-Organised workshops](/workshops/#workshop-organising), we will work with a designated Member contact to find 
 Instructors, set up and handle registration, support Instructor logistics, and coordinate and share assessment results with you. 
 Instructor travel expenses are the responsibility of the Member and are not covered in membership fees.<br><br>
@@ -62,19 +63,19 @@ membership. If you would like to run a Centrally-Organised workshops in order to
 membership at your organisation, we will count the workshop fee towards a membership if purchased within twelve (12) months.<br><br>
 Workshops can cover curricula from any of our lesson programs: [Data Carpentry](https://datacarpentry.org/lessons/), [Library Carpentry](https://librarycarpentry.org/lessons/), or [Software Carpentry](https://software-carpentry.org/lessons/).  An overview of available workshops is located on our [curricula page](/workshops-curricula/). Contact us at [{{site.workshops_contact}}](mailto:{{site.workshops_contact}}) to learn more about our workshop operations.
 
-2. **How soon after signing my membership can I get started with hosting workshops?**<br>
+### How soon after signing my membership can I get started with hosting workshops?
 Right away! You can request workshops as soon as your membership agreement is in place by completing [this form]({{ site.wrf_landing }}). To allow us time to recruit Instructors and give them time to plan the workshop with you, we generally require 2-3 months lead time to schedule a workshop. 
 
-3. **Can I run my own workshops without organisational support from The Carpentries?**<br>
+### Can I run my own workshops without organisational support from The Carpentries?
 Yes! Once you start building a team of certified Instructors, you can work with them to run Self-Organised workshops. We ask that Instructors let us know when they are planning a Self-Organised workshop in advance by completing this [form]({{site.wrf_selforg}}). This form initiates a process so that The Carpentries staff can support the workshop by providing survey links, tracking Instructor and Helper participation, and publicising the workshop on The Carpentries websites, if desired. As long as at least one Instructor is Carpentries-certified, and either the Data Carpentry, Library Carpentry, or Software Carpentry core content is taught, the workshop can be labeled a Carpentries workshop. Self-Organised workshops do not count against the number of workshops included in your membership agreement and there is no limit to the number of Self-Organised workshops you can run. 
 
-4. **What if I want to run more Centrally-Organised workshops than my agreement allows?**<br>
+### What if I want to run more Centrally-Organised workshops than my agreement allows?
 All members are eligible to purchase additional Centrally-Organised workshops at a discount. 
 Our current [pricing is here](/membership/#a-la-carte-pricing/).
 
 ## Instructor Training
 
-1. **How do your Instructor Training events run?**<br>
+### How do your Instructor Training events run?
 The Carpentries [Instructor Training](https://carpentries.github.io/instructor-training/) is a high-engagement, interactive,
 multi-day training, led by pedagogically trained community members (Trainers). Once your membership is in place, you will be 
 provided with a registration code which your selected trainees can use to register for an event of their choice from our 
@@ -82,7 +83,7 @@ provided with a registration code which your selected trainees can use to regist
 [{{site.instructor_training_contact}}](mailto:{{site.instructor_training_contact}}) to learn more about our Instructor Training 
 program.
 
-2. **How should I select individuals to be trained as Instructors?**<br>
+### How should I select individuals to be trained as Instructors?
 The choice of trainees is at the discretion of the Member. We recommend choosing trainees based on enthusiasm and 
 commitment to teaching. There are no specific technical skills required to become a Carpentries Instructor, and we welcome 
 individuals with a range of experiences and technical competencies. Trainees will be required to demonstrate their ability to
@@ -92,27 +93,27 @@ screening or selection of trainee candidates, Member organisations are welcome t
 [rubric](https://github.com/carpentries/instructor-training/blob/gh-pages/files/rubric.md), which we use for evaluating 
 non-member affiliated trainees. For more information about selecting trainees, read our [Information for Member Organizations](https://carpentries.github.io/instructor-training/members/) page.
 
-3. **How soon after signing my membership can I get started with Instructor Training?**<br>
+### How soon after signing my membership can I get started with Instructor Training?
 In your 12 month membership period, we will be offering at least 6-8 online events scheduled across various timezones. To view a full list of upcoming training events please see our [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar/). Your trainees are invited to join any event(s) that suits their schedule(s), either as a group or individually, along with new trainees from other parts of our community.<br>
 It is difficult to schedule events in every time zone, so your trainees are always welcome to join scheduled online events in adjacent time zones, given the times are reasonable for their schedule. However, knowing this may not be ideal for you, we will work with you to schedule an online event based on your needs and our Trainers’ availability. To ensure that we can meet everyone’s needs, we generally like to schedule these events 2-3 months in advance. Once this event is scheduled, we may invite people from other sites to join as well, to begin to build community in your part of the world.<br>
 
-4. **How do I find out if trainees at my site have completed Instructor Training or the certification process and how many seats remain available under my membership?**<br>
+### How do I find out if trainees at my site have completed Instructor Training or the certification process and how many seats remain available under my membership?
 For best results, we recommend tracking this locally. Keeping in touch with trainees can have additional value in building your 
 local community. Due to regional variation in privacy laws and delays in our registration workflows, not all information from our
 database is guaranteed to be available or fully up to date. You are welcome to email us at 
 [{{site.instructor_training_contact}}](mailto:{{site.instructor_training_contact}}) at any time with a request for information. We
 will reply within 3-5 business days with the information we can provide.
 
-5. **What if I do not use all of my Instructor Training seats before the end of my membership?**<br>
+### What if I do not use all of my Instructor Training seats before the end of my membership?
 The success of our program depends on accurately predicting our capacity needs, so we may not be able to accommodate all 
 situations.  However, we know unexpected things can come up. If you are nearing the end of your membership term and have not used 
 all your seats, please contact us at [{{site.membership_contact}}](mailto:{{site.membership_contact}}).
 
-6. **What if I want to train more people at my site than my agreement allows?**<br>
+### What if I want to train more people at my site than my agreement allows?
 All members are eligible to purchase additional Instructor Training seats at a discount. 
 Our current [pricing is here](/membership/#a-la-carte-pricing).
 
-7. **Can individuals get trained to become Instructors outside of the context of institutional membership?**<br>
+### Can individuals get trained to become Instructors outside of the context of institutional membership?
 Yes! Individuals can purchase Instructor Training seats at the [a la carte price](/membership/#a-la-carte-pricing)
 for their region. Individuals purchasing seats a la carte will receive equal priority with Members in scheduling.<br><br>
 Individuals who are not able to purchase seats can apply through our Open Instructor Training program. Acceptance rate varies, 

--- a/pages/member_faq.md
+++ b/pages/member_faq.md
@@ -52,6 +52,9 @@ equivalent to six (6) seats in Instructor Training per active Instructor Trainer
 A list of our [current Member organisations](https://carpentries.org/members/) can be found on our website. If you would like 
 help in making contact with the person in charge of your institutional membership, email [{{site.membership_contact}}](mailto:{{site.membership_contact}}).
 
+### What is The Carpentries Member Council?
+Member Council meetings are a quarterly opportunity for representatives from Member organisations to come together and share ideas and tips for building Carpentries community at their organisation. The Carpentries staff will also present a quarterly update on new programs, opportunities, and other topics of interest to Member organisations.
+
 ## Workshops
 
 ### How do your workshops run?

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -81,7 +81,7 @@ Costs for for-profit organisations are four times the price for not-for-profit o
 
 <p>In addition the benefits above, all Memberships include:</p>
 <ul>
-<li>opportunity to send two (2) representatives to meetings of the Member Council, which meets approximately quarterly to discuss issues of importance to Member organisations,</li>
+<li>opportunity to send two (2) representatives to meetings of the <a href="{{site.url}}/member_faq/#what-is-the-carpentries-member-council">Member Council</a>, which meets approximately quarterly to discuss issues of importance to Member organisations,</li>
 <li>opportunity to submit a candidate for our Trainer Training course, through which individuals can become certified to teach our Instructor Training courses (additional fees apply),</li>
 <li>unlimited self-organised workshops,</li>
 <li>access to Member pricing for additional Centrally-Organised workshops and Instructor Training seats purchased during the membership year. </li>


### PR DESCRIPTION
Adds a section to the member FAQ about the member council, and links to this from the membership page.

This PR also adds a TOC to the member FAQ, just like the one we already have for the workshops FAQ.