### PR TITLE
fix anchor link position

### DIFF
--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -148,3 +148,15 @@ img.lazy {
     transition: opacity 0.7s;
     opacity: 1;
 }
+
+*:target:not([id^='fn:']):not([id^='fnref:']) {
+    &::before {
+        content: " ";
+        width: 0;
+        height: 0;
+
+        display: block;
+        padding-top: 50px;
+        margin-top: -50px;
+    }
+}


### PR DESCRIPTION
This is related to #1398 but unfortunately does not address it.

It adds CSS styling that has been added to the template code base after we started using it (https://github.com/Phlow/feeling-responsive/issues/154) and addresses the issue about anchor links by adding enough hidden white space above the titles that it takes into account the top navbar.

Unfortunately, this strategy doesn't work for footnotes (they are explicitly excluded in the added CSS) because it breaks their formatting. 
