### PR TITLE
add .vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Gemfile.lock
 /_includes/_head_issue_table.html
 /_includes/_content_issue_table.html
 /_includes/_content_lesson_table.html
+
+# bundler detritus
+.vendor/


### PR DESCRIPTION
I just had to delete and re-download the repository because I had accidentally run `git add .`, which happened to try to add all 109M of the ruby gems in the `.vendor` folder (which I got via `bundle install`) and git became super sluggish because it was part of my prompt ㅠㅠ

This adds `.vendor` to `.gitignore` so that I and future people like me don't have to deal with this issue. 