### PR TITLE
add CarpentryCon 2022 to comm calendar

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -329,6 +329,11 @@ There are many opportunities to join community meetings, subcommittees
 and debriefing sessions. Find links to them on this <a href="http://pad.carpentries.org/pad-of-pads">Etherpad</a>, and subscribe to the calendar below to watch all that is
 going on throughout our community.
 
+* General community events are listed in blue.
+* [CarpentryCon 2022](https://2022.carpentrycon.org/) events are listed in orange.  Visit the CarpentryCon 2022 website for more information.
+
+
+
 <div id='calendar' markdown="0"></div>
 
 <hr>
@@ -345,6 +350,8 @@ frame.width = '800';
 frame.height = '600';
 frame.frameborder = '0';
 frame.scrolling = 'no';
-frame.src = 'https://calendar.google.com/calendar/embed?title=The%20Carpentries%20Community%20Calendar%20&mode=WEEK&src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&ctz=' + timezone.name();
+frame.src = 'https://calendar.google.com/calendar/embed?title=The%20Carpentries%20Community%20Calendar%20&mode=WEEK&src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&color=%237FB3D5&src=c_tmtrkf328gjtcs1u05mhfbn7qc%40group.calendar.google.com&color=%23BE6D00&ctz=' + timezone.name();
 document.getElementById('calendar').appendChild(frame);
 </script>
+
+

--- a/pages/community.md
+++ b/pages/community.md
@@ -330,7 +330,7 @@ and debriefing sessions. Find links to them on this <a href="http://pad.carpentr
 going on throughout our community.
 
 * General community events are listed in blue.
-* [CarpentryCon 2022](https://2022.carpentrycon.org/) events are listed in orange.  Visit the CarpentryCon 2022 website for more information.
+* CarpentryCon 2022 (31 July - 13 August 2022) events are listed in orange.  Visit the [CarpentryCon 2022 website](https://2022.carpentrycon.org/) for more information.
 
 
 


### PR DESCRIPTION

This adds the CarpentryCon 2022 calendar to the community calendar view.  
Once this is merged -- while the CarpentryCon calendar could stay up indefinitely, we should probably plan to take down the note about the two calendars being displayed in different colors. 