### PR TITLE
remove core team member

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -22,16 +22,6 @@ people:
   twitter: ErinSBecker
   calendly: ebecker-1
 
-- name: François Michonneau, PhD
-  pic: francoismichonneau
-  position: Senior Director of Technology
-  lead: Infrastructure Team Lead
-  jobplan: https://docs.google.com/document/d/1Y66RlED6a9TN1XxHZF-htJVMZ0dfmqtysFLyXSP8sk4/edit
-  email: francois@carpentries.org
-  github: fmichonneau
-  twitter: fmic_
-  calendly: francois-carpentries
-
 - name: Zhian N. Kamvar, PhD
   pic: zhiankamvar
   position: Lesson Infrastructure Technology Developer


### PR DESCRIPTION
Removes François as a Core Team member.
This is one of the saddest PRs I have had to make :cry:

Note this disrupts the balance we had with the three Executive Team members across the top.  I could fiddle with the styling of this page some more to make the top row just have two members and all other team members below.  This will take some time though. We could also keep things as they are for now and revisit as our overall team composition changes.