### PR TITLE
Update team page format

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -11,6 +11,7 @@ people:
   github: kariljordan
   twitter: drkariljordan
   calendly: kariljordan
+  et: true
 
 - name: Erin Becker, PhD
   pic: erinbecker
@@ -21,6 +22,7 @@ people:
   github: erinbecker
   twitter: ErinSBecker
   calendly: ebecker-1
+  et: true
 
 - name: Zhian N. Kamvar, PhD
   pic: zhiankamvar
@@ -29,6 +31,7 @@ people:
   github: zkamvar
   twitter: zkamvar
   calendly: zkamvar
+  et: false
 
 - name: Toby Hodges, PhD
   pic: tobyhodges
@@ -38,6 +41,7 @@ people:
   github: tobyhodges
   twitter: tbyhdgs
   calendly: tobyhodges
+  et: false
  
 - name: Talisha Sutton-Kennedy
   pic: talishasuttonkennedy
@@ -46,6 +50,7 @@ people:
   email: talishask@carpentries.org
   github: talishask
   calendly: talishask
+  et: false
  
 - name: SherAaron Hurt
   pic: sheraaronhurt
@@ -56,6 +61,7 @@ people:
   github: sheraaronhurt
   twitter: SherAaronHurt
   calendly: sheraaron
+  et: false
  
 - name: Omar Khan
   pic: omarkhan
@@ -63,6 +69,7 @@ people:
   email: okhan@carpentries.org
   github: kmomar
   calendly: okhan-1
+  et: false
  
 - name: Maneesha Sane
   pic: maneeshasane
@@ -72,6 +79,7 @@ people:
   github: maneesha
   twitter: maneeshasane
   calendly: maneesha
+  et: false
  
 - name: Kelly Barnes, PhD
   pic: kellybarnes
@@ -81,6 +89,7 @@ people:
   linkedin: klbarnes20
   twitter: kbarne2
   calendly: klbarnes
+  et: false
  
 - name: Karen Word, PhD      
   pic: karenword
@@ -91,6 +100,7 @@ people:
   github: karenword
   twitter: karen_word
   calendly: karenword
+  et: false
  
 - name: Danielle Sieh
   pic: daniellesieh
@@ -98,13 +108,13 @@ people:
   github: danielle06
   email: danielle@carpentries.org
   calendly: daniellesieh
+  et: false
 
 - name: Brynn Elliot
   pic: brynnelliot
   position: Accessibility Manager
   email: brynn@carpentries.org
-
-
+  et: false
 
 - name: Angelique Trusler, PhD
   pic: angeliquetrusler
@@ -113,13 +123,13 @@ people:
   github: elletjies
   twitter: AngeliquePhd
   calendly: angelique_v
-
+  et: false
 
 - name: Amanda Steele
   pic: amandasteele
   position: Director of Fundraising
   email: amandasteele@carpentries.org
-
+  et: false
 
 - name: Alycia Crall, PhD
   pic: alyciacrall
@@ -130,3 +140,4 @@ people:
   linkedin: alycia-crall-5a842646
   twitter: alycrall
   calendly: alycia-carpentries
+  et: false

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -14,14 +14,14 @@
     <div class="row">
       {% assign et = site.data.team.people | where: "et", true %}
       {% assign staff = site.data.team.people | where: "et", false %}
-      <div class="col-lg-12 text-center">
+      <div id="executive-team" class="col-lg-12 text-center">
       {% for member in et %}
       {% include _team_profile.html %}
       {% endfor %}
       </div>
     </div>
     <div class="row">
-      <div class="col-lg-12 text-center">
+      <div id="staff" class="col-lg-12 text-center">
       {% for member in staff %}
       {% include _team_profile.html %}
       {% endfor %}
@@ -33,7 +33,7 @@
   <h2 class="section-heading">The Carpentries Strategic Partners</h2>
     <div class="container">
       <div class="row">
-        <div class="col-lg-12 text-center">
+        <div id="strategic-partners" class="col-lg-12 text-center">
           {% assign consultants = site.data.strategic_partners.people %}
           {% for member in consultants %}
           {% include _team_profile.html %}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -12,8 +12,16 @@
 
   <div class="container">
     <div class="row">
+      {% assign et = site.data.team.people | where: "et", true %}
+      {% assign staff = site.data.team.people | where: "et", false %}
       <div class="col-lg-12 text-center">
-      {% assign staff = site.data.team.people %}
+      {% for member in et %}
+      {% include _team_profile.html %}
+      {% endfor %}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-12 text-center">
       {% for member in staff %}
       {% include _team_profile.html %}
       {% endfor %}
@@ -21,6 +29,7 @@
     </div>
 
 
+  {% if site.data.strategic_partners.people %}
   <h2 class="section-heading">The Carpentries Strategic Partners</h2>
     <div class="container">
       <div class="row">
@@ -31,6 +40,7 @@
           {% endfor %}
         </div>
       </div>
+  {% endif %}
 
 
 </section>


### PR DESCRIPTION
- team yaml has new `et` parameter that is `true` for Exec team members
- Exec Team now along top row
- Control has been added to show strategic partners if they exist
- ids for each div has been created