### PR TITLE
Take down carpentrycon

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -23,19 +23,6 @@ edit_on_github: false
 {% endif %}
 {% if page.callforaction %}
 
-<div  style="background: #f2f2f2; padding-top: 25px">
-
-    <div class="row">
-
-        <div class="small-12 text-center columns">
-
-            <a href="https://2022.carpentrycon.org/"><img src="{{ site.urlimg }}/carpentrycon2022.png" width="85%" alt="Registration is now open for CarpentryCon 2022: Expanding Data Frontiers happening 1-12 August 2022!"></a>
-
-        </div><!-- /.small-12.columns -->
-
-    </div><!-- /.row -->
-
-</div>
 {% endif %}
 
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -329,11 +329,6 @@ There are many opportunities to join community meetings, subcommittees
 and debriefing sessions. Find links to them on this <a href="http://pad.carpentries.org/pad-of-pads">Etherpad</a>, and subscribe to the calendar below to watch all that is
 going on throughout our community.
 
-* General community events are listed in blue.
-* CarpentryCon 2022 (31 July - 13 August 2022) events are listed in orange.  Visit the [CarpentryCon 2022 website](https://2022.carpentrycon.org/) for more information.
-
-
-
 <div id='calendar' markdown="0"></div>
 
 <hr>


### PR DESCRIPTION
Takes down CarpentryCon banner from front page of carpentries.org.
To be merged on August 15 2022.