### PR TITLE
another fix to deprecated ruby workflow

### DIFF
--- a/.github/workflows/check-pull-requests.yml
+++ b/.github/workflows/check-pull-requests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
 


### PR DESCRIPTION
Fixes deprecated Ruby workflow - see https://github.com/carpentries/carpentries.org/actions/runs/3590145888/jobs/6043251480#step:6:1

Like https://github.com/carpentries/carpentries.org/pull/1543, this will probably fail because meta... 