### PR TITLE
Update pricing tables and membership FAQ

### DIFF
--- a/pages/become-instructor.md
+++ b/pages/become-instructor.md
@@ -53,7 +53,7 @@ Member organisations have agreements with The Carpentries that include a specifi
 
 If you have received an access code, you are ready to use your code to [sign up for an Instructor Training event](https://carpentries.github.io/instructor-training/training_calendar/index.html)! When you register, you will also be asked to [create a profile in our database]({{site.instructor_training_app}}).
 Where membership is not possible, The Carpentries occasionally sponsors groups for Instructor Training. At this time, applications for group sponsorship are available by invitation only. However, if you have a group that you believe will advance The Carpentries’ goal of reaching historically under-represented groups through sponsorship, you are welcome to [contact us](mailto:{{site.instructor_training_contact}}) with inquiries. 
-For more information about membership and other options for group access to training, visit our [Membership page]({{site.url}}/membership/). 
+Group pricing for Instructor Training is listed below. 
 
 2\. **Apply through the Open Instructor Training Program** 
 
@@ -71,4 +71,4 @@ Individuals and organisations may pay a fee to gain access to Instructor Trainin
 
 The per seat fee is dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html). All fees listed are in USD and represent costs for not-for-profit or academic organisations. Costs for for-profit organisations are four times the fee listed for not-for-profit organisations
 
-If you are seeking to train six (6) or more individuals, please check out our [Membership page]({{site.url}}/membership/) as the rate may be lower.
+If you are seeking to train six (6) or more individuals, please check out our [Membership page]({{site.url}}/membership/) as the rate may be lower. 

--- a/pages/become-instructor.md
+++ b/pages/become-instructor.md
@@ -60,7 +60,7 @@ For more information about membership and other options for group access to trai
 The Open Instructor Training Program is a Carpentries-sponsored program in which individual applicants may be invited to receive training at no cost. Applications are scored and accepted on a rolling basis in order of scoring. This program is not for groups; multiple individuals from a single institution or cohort may be considered but will not be admitted simultaneously. [Apply to our Open Instructor Training Program]({{site.instructor_training_app}}).
 
 ## Group Training & Priority Access Fees
-Organisations may pay a fee to gain priority access to Instructor Training events and train a group of individuals. Once invoiced, we will create a unique registration code for your trainees to access registration. 
+Individuals and organisations may pay a fee to gain access to Instructor Training. Once invoiced, we will create a unique registration code that trainees can use to access registration for any event on our quarterly [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar/index.html). 
 
 |                     | Instructor Training Seat Fee (USD) |
 |---------------------|------------------------------------|

--- a/pages/become-instructor.md
+++ b/pages/become-instructor.md
@@ -58,3 +58,17 @@ For more information about membership and other options for group access to trai
 2\. **Apply through the Open Instructor Training Program** 
 
 The Open Instructor Training Program is a Carpentries-sponsored program in which individual applicants may be invited to receive training at no cost. Applications are scored and accepted on a rolling basis in order of scoring. This program is not for groups; multiple individuals from a single institution or cohort may be considered but will not be admitted simultaneously. [Apply to our Open Instructor Training Program]({{site.instructor_training_app}}).
+
+## Group Training & Priority Access Fees
+Organisations may pay a fee to gain priority access to Instructor Training events and train a group of individuals. Once invoiced, we will create a unique registration code for your trainees to access registration. 
+
+|                     | Instructor Training Seat Fee (USD) |
+|---------------------|------------------------------------|
+| High Income         | $1,500                             |
+| Upper-Middle Income | $1,125                             |
+| Lower-Middle Income | $750                               |
+| Low Income          | $375                               |
+
+The per seat fee is dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html). All fees listed are in USD and represent costs for not-for-profit or academic organisations. Costs for for-profit organisations are four times the fee listed for not-for-profit organisations
+
+If you are seeking to train six (6) or more individuals, please check out our [Membership page]({{site.url}}/membership/) as the rate may be lower.

--- a/pages/member_faq.md
+++ b/pages/member_faq.md
@@ -43,7 +43,7 @@ and Gold memberships only, and is subject to availability. Organisations awarded
 Organisations supporting [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html), who engage in
 service activities to teach and support newly trained Instructors across our global community, may be eligible for a discount to their membership fee 
 equivalent to six (6) seats in Instructor Training per active Instructor Trainer. Members can choose whether they would like to have the Trainer discount applied as a monetary discount, or as added benefits.  This discount is available at any membership level, for each trainer who has participated in the following activities up to 1 year prior to renewal:
-* teach at least 2 Instructor Training events for the global Carpentries community,
+* teach at least two (2) Instructor Training events for the global Carpentries community,
 * host at least 2 teaching demonstrations for the global Carpentries community, and
 * attend virtual Trainer community meetings
 

--- a/pages/member_faq.md
+++ b/pages/member_faq.md
@@ -41,8 +41,11 @@ and Gold memberships only, and is subject to availability. Organisations awarded
 
 ### Are any other discounts available?
 Organisations supporting [Instructor Trainers](https://docs.carpentries.org/topic_folders/instructor_training/duties_agreement.html), who engage in
-service activities to teach and support newly trained Instructors across our global community, are eligible for a discount to their membership fee 
-equivalent to six (6) seats in Instructor Training per active Instructor Trainer. Members can choose whether they would like to have the Trainer discount applied as a monetary discount, or as added benefits.  This discount is available at any membership level. 
+service activities to teach and support newly trained Instructors across our global community, may be eligible for a discount to their membership fee 
+equivalent to six (6) seats in Instructor Training per active Instructor Trainer. Members can choose whether they would like to have the Trainer discount applied as a monetary discount, or as added benefits.  This discount is available at any membership level, for each trainer who has participated in the following activities up to 1 year prior to renewal:
+* teach at least 2 Instructor Training events for the global Carpentries community,
+* host at least 2 teaching demonstrations for the global Carpentries community, and
+* attend virtual Trainer community meetings
 
 ### How can I find out if my institution already has a membership?
 A list of our [current Member organisations](https://carpentries.org/members/) can be found on our website. If you would like 

--- a/pages/member_faq.md
+++ b/pages/member_faq.md
@@ -44,7 +44,7 @@ Organisations supporting [Instructor Trainers](https://docs.carpentries.org/topi
 service activities to teach and support newly trained Instructors across our global community, may be eligible for a discount to their membership fee 
 equivalent to six (6) seats in Instructor Training per active Instructor Trainer. Members can choose whether they would like to have the Trainer discount applied as a monetary discount, or as added benefits.  This discount is available at any membership level, for each trainer who has participated in the following activities up to 1 year prior to renewal:
 * teach at least two (2) Instructor Training events for the global Carpentries community,
-* host at least 2 teaching demonstrations for the global Carpentries community, and
+* host at least two (2) teaching demonstrations for the global Carpentries community, and
 * attend virtual Trainer community meetings
 
 ### How can I find out if my institution already has a membership?

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-    <li>Add six (6) instructor training seats to the membership or</li>
     <li>Reduce the membership fee by $5,400 <i>(only if the total membership fee remains greater than or equal to $0)</i></li>
   </ul>
 <p><strong>Trainer Eligibility Requirements</strong></p>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-<p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -139,7 +139,7 @@ through the application process.  </p>
 </table> 
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
-<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
+<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](https://carpentries.org/member_faq/#are-any-other-discounts-available).</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -142,7 +142,6 @@ through the application process.  </p>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
 <ul>
-  <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -139,7 +139,7 @@ through the application process.  </p>
 </table> 
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
-<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](https://carpentries.org/member_faq/#are-any-other-discounts-available).</p>
+<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see <a href="https://carpentries.org/member_faq/#are-any-other-discounts-available">our FAQ</a>.</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-  <ul>
     <li>Add six (6) instructor training seats to the membership or</li>
     <li>Reduce the membership fee by $5,400 <i>(only if the total membership fee remains greater than or equal to $0)</i></li>
   </ul>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -143,7 +143,6 @@ through the application process.  </p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
 <ul>
   <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
-  <li>host at least 2 teaching demonstrations for the global Carpentries community, and</li>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -147,7 +147,6 @@ through the application process.  </p>
 <ul>
   <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
   <li>host at least 2 teaching demonstrations for the global Carpentries community, and</li>
-  <li>attend virtual Trainer community meetings</li>
 </ul>
 <p>If the Trainer received their certification less than 1 year before renewal, the above acitivies will be prorated.</p>
 

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -139,7 +139,7 @@ through the application process.  </p>
 </table> 
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
-<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership.</p>
+<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
 <p>For each Trainer who meets the eligibility requirements above, you choose one of the following:</p>
   <ul>
     <li>Add six (6) instructor training seats to the membership or</li>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -108,7 +108,7 @@ through the application process.  </p>
 </a>
 
 <h3 id="a-la-carte-pricing">Membership Add-On Pricing</h3>
-<p>All membership levels are customizable. Members have access to discounted rates and may add Centrally-Orgnised Workshops or Instructor Training seats to their membership at time.</p>
+<p>All membership levels are customizable. Members have access to discounted rates and may add Centrally-Orgnised Workshops or Instructor Training seats to their membership at any time.</p>
 
 <table>
   <tr>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-<p>For each Trainer who meets the eligibility requirements above, you choose one of the following:</p>
   <ul>
     <li>Add six (6) instructor training seats to the membership or</li>
     <li>Reduce the membership fee by $5,400 <i>(only if the total membership fee remains greater than or equal to $0)</i></li>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -43,7 +43,7 @@ Costs for for-profit organisations are four times the price for not-for-profit o
     <td>0</td>
   </tr>
   <tr>
-    <th colspan=6>Membership Dues (USD Annual) per <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s income categorisation</a></th>
+    <th colspan=6>Membership Fee (USD Annual) per <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s income categorisation</a></th>
   </tr>
   <tr>
     <th>High income</th>
@@ -87,62 +87,11 @@ Costs for for-profit organisations are four times the price for not-for-profit o
 <li>access to Member pricing for additional Centrally-Organised workshops and Instructor Training seats purchased during the membership year. </li>
 </ul>
 
-
 <a href="https://carpentries.typeform.com/to/Hmfe6L">
   <button class="btn">
     Become a Member Organisation
   </button>
 </a>
-
-<h3 id="a-la-carte-pricing">A La Carte Pricing</h3>
-<p>Centrally-Organised workshops and Instructor Training are also offered independently of Memberships, to organisations or individuals
-who would like to purchase these benefits a la carte. </p>
-
-
-<table>
-  <tr>
-      <th colspan=6>A la carte Prices (USD)</th>
-  </tr>
-  <tr>
-      <th colspan=2></th>
-      <th colspan=2>Centrally-Organised workshops</th>
-      <th colspan=2>Instructor Training seat</th>
-  </tr>
-  <tr>
-    <th colspan=2></th>
-  	<th>Member</th>
-    <th>General Public</th>
-    <th>Member</th>
-    <th>General Public</th>
-  <tr>
-    <th colspan=2>High income</th>
-    <td>$1,800</td>
-    <td>$3,000</td>
-    <td>$900</td>
-	<td>$1,500</td>
-  </tr>
-  <tr>
-    <th colspan=2>Upper-middle income</th>
-    <td>$1,350</td>
-    <td>$2,250</td>
-    <td>$675</td>
-	<td>$1,125</td>
-  </tr>
-    <tr>
-    <th colspan=2>Lower-middle income</th>
-    <td>$900</td>
-    <td>$1,500</td>
-    <td>$450</td>
-	<td>$750</td>
-  </tr>
-  <tr>
-    <th colspan=2>Low income</th>
-    <td>$450</td>
-    <td>$750</td>
-    <td>$225</td>
-	<td>$375</td>
-  </tr>
-</table> 
 
 <h3 id="financial-support">Financial Support</h3>
 <p>Organisations applying for membership at the Bronze, Silver, and Gold levels are eligible to apply for 
@@ -158,6 +107,52 @@ through the application process.  </p>
   </button>
 </a>
 
+<h3 id="a-la-carte-pricing">Membership Add-On Pricing</h3>
+<p>All membership levels are customizable. Members have access to discounted rates and may add Centrally-Orgnised Workshops or Instructor Training seats to their membership at time.</p>
+
+<table>
+  <tr>
+      <th></th>
+      <th>Centrally-Organised Workshops</th>
+      <th>Instructor Training Seat</th>
+  </tr>
+  <tr>
+    <th>High income</th>
+    <td>$1,800</td>
+    <td>$900</td>
+  </tr>
+  <tr>
+    <th>Upper-middle income</th>
+    <td>$1,350</td>
+	  <td>$675</td>
+  </tr>
+    <tr>
+    <th>Lower-middle income</th>
+    <td>$900</td>
+  	<td>$450</td>
+  </tr>
+  <tr>
+    <th>Low income</th>
+    <td>$450</td>
+	  <td>$225</td>
+  </tr>
+</table> 
+
+<h3 id="a-la-carte-pricing">Trainer Discounts</h3>
+<p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership.</p>
+<p>For each Trainer who meets the eligibility requirements above, you choose one of the following:</p>
+  <ul>
+    <li>Add six (6) instructor training seats to the membership or</li>
+    <li>Reduce the membership fee by $5,400 <i>(only if the total membership fee remains greater than or equal to $0)</i></li>
+  </ul>
+<p><strong>Trainer Eligibility Requirements</strong></p>
+<p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
+<ul>
+  <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
+  <li>host at least 2 teaching demonstrations for the global Carpentries community, and</li>
+  <li>attend virtual Trainer community meetings</li>
+</ul>
+<p>If the Trainer received their certification less than 1 year before renewal, the above acitivies will be prorated.</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -147,7 +147,6 @@ through the application process.  </p>
 <ul>
   <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
   <li>host at least 2 teaching demonstrations for the global Carpentries community, and</li>
-</ul>
 <p>If the Trainer received their certification less than 1 year before renewal, the above acitivies will be prorated.</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-  </ul>
 <p><strong>Trainer Eligibility Requirements</strong></p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
 <ul>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -147,7 +147,6 @@ through the application process.  </p>
 <ul>
   <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>
   <li>host at least 2 teaching demonstrations for the global Carpentries community, and</li>
-<p>If the Trainer received their certification less than 1 year before renewal, the above acitivies will be prorated.</p>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-    <li>Reduce the membership fee by $5,400 <i>(only if the total membership fee remains greater than or equal to $0)</i></li>
   </ul>
 <p><strong>Trainer Eligibility Requirements</strong></p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -141,7 +141,6 @@ through the application process.  </p>
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
-<ul>
 
 <h3 id="frequently-asked-questions">Frequently Asked Questions</h3>
 <p>Please consult our <a href="/member_faq">Membership FAQ page</a> for more information about memberships, workshops, Instructor Training and Trainer Training.

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -140,7 +140,6 @@ through the application process.  </p>
 
 <h3 id="a-la-carte-pricing">Trainer Discounts</h3>
 <p>Member organisations with active Instructor Trainers (also referred to as Trainers) may be eligible for a discount on their membership. For more details see [our FAQ](/member_faq/#are-any-other-discounts-available).</p>
-<p><strong>Trainer Eligibility Requirements</strong></p>
 <p>In the 1 year prior to renewal, Trainers who have completed the following are eligible for an organisational discount:</p>
 <ul>
   <li>teach at least 2 Instructor Training events for the global Carpentries community,</li>

--- a/pages/workshops.html
+++ b/pages/workshops.html
@@ -288,7 +288,29 @@ Our instructors are volunteers and are not paid for their time teaching. Therefo
 <li>The administration fee is used to support staff time with this partnership. You will be provided with exceptional customer service and timely support from our Workshop Administration Team and Regional Coordinators. </li>
 </ul>
 
-<p>View <a href="/membership/#a-la-carte-pricing">workshop administration fees here for member and non-member organisations</a>. </p>
+<p>The workshop fee is dependent on the purchasing organisation's geographic location, according to the <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank's gross national income categorisation</a>. All fees listed are in USD and represent costs for not-for-profit or academic organisations. Costs for for-profit organisations are four times the fee listed for not-for-profit organisations.</p>
+<table>
+  <tr>
+      <th></th>
+      <th>Centrally-Organised Workshop Fee (USD)</th>
+  </tr>
+  <tr>
+    <th>High income</th>
+    <td>$3,000</td>
+  </tr>
+  <tr>
+    <th>Upper-middle income</th>
+    <td>$2,250</td>
+  </tr>
+    <tr>
+    <th>Lower-middle income</th>
+    <td>$1,500</td>
+  </tr>
+  <tr>
+    <th>Low income</th>
+    <td>$750</td>
+  </tr>
+</table> 
 
 
 <h3>Workshop Administration Financial Support</h3>

--- a/pages/workshops.html
+++ b/pages/workshops.html
@@ -292,7 +292,7 @@ Our instructors are volunteers and are not paid for their time teaching. Therefo
 <table>
   <tr>
       <th></th>
-      <th>Centrally-Organised Workshop Fee (USD)</th>
+      <th>Workshop Administration Fee (USD)</th>
   </tr>
   <tr>
     <th>High income</th>


### PR DESCRIPTION
In response to questions about pricing, a-la-carte pricing and discounts I've made a few updates to our current website.

The membership page has been updated as follows:
- A-la-carte pricing has been changed to Membership Add-On pricing only. The purpose of this update is to simplify the pricing table by showing only the member discounted add-on rates and remove a la carte pricing from the membership page.
- include a section describing the trainer discount

The membership FAQ has been updated as follows:
- update trainer discount information

The workshops page (@carpentries/core-team-workshop-admin) was updated to:
-  include an administration fee table 
- remove information directing folks to the membership page for pricing

The instructor training page (@carpentries/core-team-instructor-training) was updated to add a la carte pricing.

