### PR TITLE
add instructor training landing pages

### DIFF
--- a/pages/instructor-training/confirmation.md
+++ b/pages/instructor-training/confirmation.md
@@ -28,7 +28,7 @@ Before your training, please visit our [Preparing for Instructor Training page](
 3. Please read the following:
   
   - ["The Science of Learning"](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
-  - ["The Carpentries Annual Report"](https://carpentries.org/files/reports/Carpentries2020AnnualReport.pdf)
+  - ["The Carpentries Annual Report"](https://carpentries.org/files/reports/2021%20Carpentries%20Annual%20Report_Final.pdf)
 
 ## Checkout: The Instructor Certification Process
 

--- a/pages/instructor-training/confirmation.md
+++ b/pages/instructor-training/confirmation.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: Registration Confirmation Page
+title: Instructor Training Registration Confirmation Page
 permalink: instructor-training/confirmation/
 exclude: true
 ---
 
-# Thank you for registering!
+## Thank you for registering!
 
 Thank you for registering for a Carpentries Instructor Training event. You should be getting an email from Eventbrite to confirm your registration.
 

--- a/pages/instructor-training/confirmation.md
+++ b/pages/instructor-training/confirmation.md
@@ -19,7 +19,7 @@ If you do not receive this email, please check your spam folder and email [instr
 
 ## How to Prepare for Instructor Training
 
-Before your training, please visit our [Preparing for Instructor Training page](https://carpentries.github.io/instructor-training/setup.html) for complete instructions. A brief summary of these instructions is as follows:
+Before your training, please visit our [Preparing for Instructor Training page](https://carpentries.github.io/instructor-training#setup) for complete instructions. A brief summary of these instructions is as follows:
 
 1. Complete our Pre-training Survey. You will receive a custom link for your event when you receive your connection information.
 
@@ -32,7 +32,7 @@ Before your training, please visit our [Preparing for Instructor Training page](
 
 ## Checkout: The Instructor Certification Process
 
-After your training, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html) and will be discussed at your training.
+After your training, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout.html) and will be discussed at your training.
 
 ## If you Need to Reschedule or Cancel
 

--- a/pages/instructor-training/confirmation.md
+++ b/pages/instructor-training/confirmation.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Registration Confirmation Page
+permalink: instructor-training/confirmation/
+exclude: true
+---
+
+# Thank you for registering!
+
+Thank you for registering for a Carpentries Instructor Training event. You should be getting an email from Eventbrite to confirm your registration.
+
+## How to Connect to the Training
+
+This event will be conducted online using the Zoom video conferencing platform.  You will *not* receive connection information through Eventbrite.
+
+One week before the event you will receive an email from [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) with preparation instructions and connection information.
+
+If you do not receive this email, please check your spam folder and email [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org). Please note that this mailbox is not continuously monitored, so be sure to check for this email well ahead of the time of your training.
+
+## How to Prepare for Instructor Training
+
+Before your training, please visit our [Preparing for Instructor Training page](https://carpentries.github.io/instructor-training/setup.html) for complete instructions. A brief summary of these instructions is as follows:
+
+1. Complete our Pre-training Survey. You will receive a custom link for your event when you receive your connection information.
+
+2. Select a lesson to use for teaching practice sessions, spending no more than 20-30 minutes to prepare.
+
+3. Please read the following:
+  
+  - ["The Science of Learning"](https://carpentries.github.io/instructor-training/files/papers/science-of-learning-2015.pdf)
+  - ["The Carpentries Annual Report"](https://carpentries.org/files/reports/Carpentries2020AnnualReport.pdf)
+
+## Checkout: The Instructor Certification Process
+
+After your training, we ask you to complete three follow-up tasks to become a certified Instructor. These requirements are detailed on our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html) and will be discussed at your training.
+
+## If you Need to Reschedule or Cancel
+
+Cancellation may be performed in Eventbrite up to the start of the event. To support our program and honor the time donated by our Instructor Trainers, we ask that cancellations be made as far in advance as possible to allow other trainees to register before the 1 week deadline.
+
+After a registration has been cancelled in Eventbrite, the code that was used to register will become available to sign up for a different event.
+
+If a trainee repeatedly registers and cancels (more than 3 times), or registers for more than one seat at the same time, they may be barred from further registration.
+
+More details on our [cancellation and makeup policy](https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html) are available in The Carpentries Handbook.
+
+## Learn More and Get Connected
+
+You can read more about [The Carpentries](https://carpentries.org/) and its lesson programs, [Data Carpentry](https://datacarpentry.org/), [Library Carpentry](https://librarycarpentry.org/), and [Software Carpentry](https://software-carpentry.org/) on our websites. Read about all the ways to get involved in The Carpentries, including signing up for mailing lists and newsletters.
+
+Please contact [instructor.training@carpentries.org](mailto:instructor.training@carpentries.org) with any other questions.
+
+

--- a/pages/instructor-training/events.md
+++ b/pages/instructor-training/events.md
@@ -8,9 +8,9 @@ permalink: /instructor-training/events
 
 This training is designed for people who want to become certified Carpentries instructors. We recommend that you be familiar with at least one of the technologies that we teach (R, Python, the Unix bash shell, SQL, OpenRefine, spreadsheet software, and/or Git) before taking Instructor Training. This training will not teach any of those subjects, but will instead focus on developing skill and knowledge about evidence-based teaching practices and workshop procedures.
 
-For more information about what will be covered at this training as well as a sample schedule, check out our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/).
+For more information about what will be covered at this training as well as a sample schedule, check out our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training).
 
-In addition to Instructor Training, certification as a Carpentries Instructor includes 3 short ‘checkout' steps. For more details, see our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html).
+In addition to Instructor Training, certification as a Carpentries Instructor includes 3 short ‘checkout' steps. For more details, see our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout).
 
 ### How to Register for an Instructor Training
 

--- a/pages/instructor-training/events.md
+++ b/pages/instructor-training/events.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: Instructor Training Calendar
+permalink: /instructor-training/events
+---
+
+### About Carpentries Instructor Training
+
+This training is designed for people who want to become certified Carpentries instructors. We recommend that you be familiar with at least one of the technologies that we teach (R, Python, the Unix bash shell, SQL, OpenRefine, spreadsheet software, and/or Git) before taking Instructor Training. This training will not teach any of those subjects, but will instead focus on developing skill and knowledge about evidence-based teaching practices and workshop procedures.
+
+For more information about what will be covered at this training as well as a sample schedule, check out our [Instructor Training Curriculum](https://carpentries.github.io/instructor-training/).
+
+In addition to Instructor Training, certification as a Carpentries Instructor includes 3 short ‘checkout' steps. For more details, see our [Checkout Instructions page](https://carpentries.github.io/instructor-training/checkout/index.html).
+
+### How to Register for an Instructor Training
+
+Invited trainees can register for events listed below by clicking on the link for that event and completing the registration through Eventbrite. When you were invited, you should have received a registration code. If you are an Open Instructor Training applicant, please see your acceptance email for your code. If you were invited through a member organisation or other group, contact the person who invited you if you did not receive a registration code from them.
+
+### When to Register
+
+#### Members and other groups
+
+Registration codes provided to members and other groups are active immediately and may be used for any event until one week prior to its start date.
+
+#### Open Instructor Training
+
+Open Instructor Training codes become active for each event starting one month before the start date. All events are closed one week before their start date. Please register for only one training; duplicate registrations may be deleted.
+
+### Cancellation Policies
+
+Cancellation may be performed in Eventbrite up to the start of the event. To support our program and honor the time donated by our Instructor Trainers, we ask that cancellations be made as far in advance as possible to allow other trainees to register before the 1 week deadline.
+
+After a registration has been cancelled in Eventbrite, the code that was used to register will become available to sign up for a different event.
+
+If a trainee repeatedly registers and cancels (>3 times), or registers for more than one seat at the same time, they may be barred from further registration.
+
+#### Attendance
+
+Trainees who miss more than 1 hour of an Instructor Training event may be marked absent. Instructor certification cannot be completed without full attendance at an Instructor Training event.
+
+A link is provided next to each event that will convert the start time to your local time zone. Please be sure to verify your availability for the full instructional time of your event. If you expect to miss more than a total of 1 hour, please select a different event.
+
+More details on our [cancellation and makeup policy](https://docs.carpentries.org/topic_folders/instructor_training/cancellations_and_makeups.html) are available in The Carpentries Handbook.
+
+### Upcoming Instructor Training
+
+New trainings are added to this calendar on a quarterly basis.
+
+<hr>
+
+#### [April 18-19, 2023](https://www.eventbrite.com/e/online-instructor-training-april-18-19-2023-tickets-568423047637)
+
+**Two 8-hour days:** 9 am to 5 pm N. America Central Time / 11 am to 7 pm Argentina Time /
+[See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230418T09&p1=64&ah=8)
+
+<hr>
+
+#### [April 26-27, 2023](https://www.eventbrite.com/e/online-instructor-training-april-26-27-2023-tickets-568436357447)
+
+**Two 8-hour days:** 9 am to 5 pm Central European Summer Time / 12:30 pm to 8:30 pm India Standard Time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230426T09&p1=195&ah=8)
+
+<hr>
+
+#### [May 10-11, 2023](https://www.eventbrite.com/e/online-instructor-training-may-10-11-2023-tickets-568443518867)
+
+**Two 8-hour days:** 9 am to 5 pm N. America Pacific Time / 12 noon to 8 pm N. America Eastern time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230510T09&p1=137&ah=8)
+
+<hr>
+
+#### [May 16-19, 2023](https://www.eventbrite.com/e/online-instructor-training-may-16-19-2023-tickets-568445484747)
+
+**Four 4-hour days:** 1 pm to 5 pm N. America Mountain Time / 7 am to 11 am **FOLLOWING DAY** New Zealand Time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230516T13&p1=42&ah=4)
+
+<hr>
+
+#### [June 1-2, 2023](https://www.eventbrite.com/e/online-instructor-training-june-1-2-2023-tickets-568447530867)
+
+**Two 8-hour days:** 9 am to 5 pm N. America Eastern Time / 2 pm to 10 pm British Summer Time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230601T09&p1=77&ah=8)
+
+<hr>
+
+#### [June 13-16, 2023](https://www.eventbrite.com/e/online-instructor-training-june-13-16-2023-tickets-568451201847)
+
+**Four 4-hour days:** 9 am to 1 pm Central European Summer Time / 12:30 pm to 4:30 pm India Standard Time / 5 pm to 9 pm Australia Eastern Standard Time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230613T09&p1=195&ah=4)
+
+<hr>
+
+#### [June 29-30, 2023](https://www.eventbrite.com/e/online-instructor-training-june-29-30-2023-tickets-568452846767)
+
+**Two 8-hour days:** 9 am to 5 pm UTC / 11 am to 6 pm Central European Summer Time / [See the start date and time in your time zone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Instructor+Training+Event&iso=20230629T09&p1=1440&ah=8)
+
+<hr>

--- a/pages/instructor-training/events.md
+++ b/pages/instructor-training/events.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Instructor Training Calendar
-permalink: /instructor-training/events
+permalink: /instructor-training/events/
 ---
 
 ### About Carpentries Instructor Training


### PR DESCRIPTION
This will implement the paths of

<https://carpentries.org/instructor-training/confirmation/> and
<https://carpentries.org/instructor-training/events/>

to replace the pages that are currently on the instructor training lesson page right now.

This will have no impact on normal website operations, but will provide a pathway to update the instructor training checkout process to align with the plans for the beta website. 

I have renamed [`registration_confirmation.md`](https://github.com/carpentries/instructor-training/blob/6499cb2fcedb37612df22a5752e496c43353d752/instructors/registration_confirmation.md) to `confirmation.md` and [`training_calendar.md`](https://github.com/carpentries/instructor-training/blob/6499cb2fcedb37612df22a5752e496c43353d752/learners/training_calendar.md) to `events.md`.

Note the preview shows that these pages work:

<https://deploy-preview-1607--stupefied-einstein-5bde90.netlify.app/instructor-training/confirmation/>
<https://deploy-preview-1607--stupefied-einstein-5bde90.netlify.app/instructor-training/events/>
