### PR TITLE
Close comms position

### DIFF
--- a/pages/communications-coordinator.md
+++ b/pages/communications-coordinator.md
@@ -4,6 +4,10 @@ title: "Communications Coordinator"
 permalink: /communications-coordinator/
 ---
 
+Posting date: 24 January 2023
+
+**We are no longer reviewing applications for this position.**
+
 [The Carpentries](http://carpentries.org/) is committed to training and fostering an active, inclusive, diverse community of learners and instructors who promote and model the importance of software and data in research. We seek an engaged and collaborative individual who shares this vision for a full-time position as the Communications Coordinator for The Carpentries. 
 
 ## Job Summary 

--- a/pages/jobs.md
+++ b/pages/jobs.md
@@ -4,7 +4,4 @@ title: "Job Opportunities with The Carpentries"
 permalink: /jobs/
 ---
 
-## Communications Coordinator
-**_Priority Consideration Deadline: Thursday, 9 February midnight anytime on Earth_**
-
-<a class="radius button small" href="{{ site.url }}{{ site.baseurl }}{% link pages/communications-coordinator.md %}">Learn more about this position</a>
+There are no current job openings with The Carpentries.


### PR DESCRIPTION
Remove communications coordinator position from jobs page and add note to job posting that we are no longer reviewing applications for this position. 