### PR TITLE
Correct CAC handbook link

### DIFF
--- a/pages/curriculum-advisors.html
+++ b/pages/curriculum-advisors.html
@@ -8,7 +8,7 @@ permalink: /curriculum-advisors/
 {% include lazyload.html %}
 
 <p>
-    Curriculum Advisors are part of a team that provides the oversight, vision, and leadership for a particular set of lessons. Committees can be reached by email using the addresses listed below, or in GitHub by using the @ tag to reference the appropriate Curriculum Advisory team (e.g. "@datacarpentry/curriculum-advisors-astronomy") in an Issue, Pull Request, or comment. More information about the Curriculum Advisory Committees can be found in <a href="{{site.handbook_url}}/topic_folders/lesson_development/lesson_development_roles.html">The Carpentries Handbook</a>.
+    Curriculum Advisors are part of a team that provides the oversight, vision, and leadership for a particular set of lessons. Committees can be reached by email using the addresses listed below, or in GitHub by using the @ tag to reference the appropriate Curriculum Advisory team (e.g. "@datacarpentry/curriculum-advisors-astronomy") in an Issue, Pull Request, or comment. More information about the Curriculum Advisory Committees can be found in <a href="{{site.handbook_url}}/topic_folders/lesson_development/curriculum_advisory_committees.html">The Carpentries Handbook</a>.
 
 </p>
 


### PR DESCRIPTION
Replace outdated handbook link with current CAC link.
