### PR TITLE
Fix formatting on Nov '22 accathon post

### DIFF
--- a/_posts/2022/11/2022-11-28-accathon.md
+++ b/_posts/2022/11/2022-11-28-accathon.md
@@ -27,7 +27,7 @@ Don’t
 * Describe purely decorative images - but do enter something to mark the absent image
 
 ## Alt Texts for Charts and Graphs
-Charts can be complicated. It is challenging to grasp the full concept of a chart in just a few short words. Amy Cesal, co-founder of the Data Visualization Society, , created a template that we have adopted for The Carpentries images. Writing Alt Text for Data Visualization | by Amy Cesal | Nightingale | Medium
+Charts can be complicated. It is challenging to grasp the full concept of a chart in just a few short words. Amy Cesal, co-founder of the Data Visualization Society, created a template that we have adopted for The Carpentries images: [Writing Alt Text for Data Visualization](https://medium.com/nightingale/writing-alt-text-for-data-visualization-2a218ef43f81)
 
 Alt = chart type of type of data where reason for including the chart
 
@@ -39,14 +39,14 @@ Alt= (chart type) Scatter plot of (type of data) hindfoot length versus weight w
 ## Our process
 After introducing community members to the whys and hows of creating alt text, we worked collaboratively to add alt text to images across our lessons.
 - Erin Becker and Zhian Kamvar, members of The Carpentries Core Team worked together to create a spreadsheet of images from our curricula. These showed which images did and did not have alt text.
-- Community members who joined the discussion  drafted alt text for an image and added it to the spreadsheet.
+- Community members who joined the discussion drafted alt text for an image and added it to the spreadsheet.
 - A second person reviewed and approved the alt text.
 - The alt text was added to the lesson on GitHub through a Pull Request, which was reviewed and merged by the Lesson Maintainer.
 
 ## How did we do?
 We are making steady progress towards having good alt text for all of our lesson images. Prior to [our first Acc-athon](https://carpentries.org/blog/2021/04/Acc-athon/), in early 2021, 53% of images in our official stable lessons lacked acceptable alt text, or a total of 323 images. By April 2021, this number was down to 40% (239 images). Between April 2021 and September 2022, contributions from community members further improved accessibility of our images, reducing the number needing alt text to 24% (150 images). The latest acc-athon resulted in alt text being added or improved for 55 images, leaving us with 95 images still needing alt text (or about 15%
 
-##How can you help?
+## How can you help?
 We have made even more progress, however, we still have more work to do. We need your help for images in the curriculum in both English and Spanish. Alt text is such an important addition and would be a great lesson contribution for Instructor checkout! There are several ways you can check to see if images have alt text: 1. Right click on the image, select “Inspect” or “Inspect Element” and check the code for alt text, 2. Turn on a screen-reader and select the picture and hear how it is described, 3. Turn off images for webpage, (this can be found in your browser settings) alt text will show instead of the image.  If there is no alt text, the image could appear like this:
 ![Sample of how broken image renders without alt text]({{ site.urlimg }}/blog/2022/11/image1.png)
 
@@ -57,8 +57,8 @@ Format: `![Alt text here](image link here) Example: ![Diagram illustrating use o
 ### HTML
 Format: `<img src="image link here" width="do not change this number" alt="Alt text here"> Example: <img src="../fig/logging-onto-cloud_1.png" width="500" alt="Screenshot of AWS EC2 dashboard showing location of launch instance button.">`
 
-R Markdown
+### R Markdown
 ```{r, fig.alt = "alt text here”}```
 
-Workbench
+### Workbench
 [The Carpentries Workbench - Transition Guide: From Styles to Workbench ](https://carpentries.github.io/workbench/transition-guide.html#figures)

--- a/_posts/2022/11/2022-11-28-accathon.md
+++ b/_posts/2022/11/2022-11-28-accathon.md
@@ -54,6 +54,11 @@ We have made even more progress, however, we still have more work to do. We need
 ### Markdown
 Format: `![Alt text here](image link here) Example: ![Diagram illustrating use of select function to select two columns of a data frame](../fig/13-dplyr-fig1.png)`
 
+_[Update June 2023: the syntax for adding alternative text to images has changed since this blog post was published.
+When the new lesson infrastructure, [The Carpentries Workbench](https://carpentries.github.io/workbench/), was introduced in May 2023, 
+the syntax for describing an image in the source file of a lesson became:
+`[Optional caption text for image goes here](path/to/image/file/goes/here){alt='alternative text description goes here'}`]_
+
 ### HTML
 Format: `<img src="image link here" width="do not change this number" alt="Alt text here"> Example: <img src="../fig/logging-onto-cloud_1.png" width="500" alt="Screenshot of AWS EC2 dashboard showing location of launch instance button.">`
 


### PR DESCRIPTION
Also adding a more detailed note about how the Markdown syntax for images has changed since the Workbench was rolled out.