### PR TITLE
Options for Core Team alt text 

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -24,6 +24,7 @@ people:
   twitter: ErinSBecker
   calendly: ebecker-1
   et: true
+  alt_text: 
 
 - name: Zhian N. Kamvar, PhD
   pronouns:  he/him/his
@@ -34,6 +35,7 @@ people:
   twitter: zkamvar
   calendly: zkamvar
   et: false
+  alt_text: 
  
 - name: Talisha Sutton-Kennedy
   pronouns: Any pronouns will do 
@@ -45,6 +47,7 @@ people:
   github: talishask
   calendly: talishask
   et: false
+  alt_text: 
  
 - name: SherAaron Hurt
   pic: sheraaronhurt
@@ -57,6 +60,7 @@ people:
   twitter: SherAaronHurt
   calendly: sheraaron
   et: false
+  alt_text: 
   
 - name: Robert Davey, PhD
   pic: robertdavey
@@ -70,6 +74,7 @@ people:
   twitter: froggleston
   calendly: froggleston
   et: false 
+  alt_text: 
  
 - name: Oscar Masinyana
   pic: oscarmasinyana
@@ -81,6 +86,7 @@ people:
   linkedin: oscar-masinyana
   calendly: oscar-masinyana-carpentries
   et: false
+  alt_text: 
 
 - name: Maneesha Sane
   pronouns: Any pronouns will do
@@ -91,6 +97,7 @@ people:
   github: maneesha
   calendly: maneesha
   et: false
+  alt_text: 
  
 - name: Kelly Barnes, PhD
   pic: kellybarnes
@@ -102,6 +109,7 @@ people:
   twitter: kbarne2
   calendly: klbarnes
   et: false
+  alt_text: 
  
 - name: Karen Word, PhD      
   pronouns: she/her/hers
@@ -114,6 +122,7 @@ people:
   twitter: karen_word
   calendly: karenword
   et: false
+  alt_text: 
   
 - name: Eli Chadwick
   pronouns: he/him and they/them
@@ -124,6 +133,7 @@ people:
   twitter: eelichad
   calendly: elichadwick
   et: false
+  alt_text: 
 
 - name: Danielle Sieh
   pronouns: she/her/hers
@@ -133,6 +143,7 @@ people:
   email: danielle@carpentries.org
   calendly: daniellesieh
   et: false
+  alt_text: 
 
 - name: Brynn Elliott
   pronouns: she/her/hers
@@ -142,6 +153,7 @@ people:
   github:  brynnelliott
   calendly: brynnelliott
   et: false
+  alt_text: 
 
 - name: Angelique Trusler, PhD
   pronouns: Any pronouns will do
@@ -152,6 +164,7 @@ people:
   twitter: AngeliquePhd
   calendly: angelique_v
   et: false
+  alt_text: 
 
 - name: Alycia Crall, PhD
   pronouns: she/her/hers
@@ -164,3 +177,4 @@ people:
   twitter: alycrall
   calendly: alycia-carpentries
   et: false
+  alt_text: 

--- a/_includes/_team_profile.html
+++ b/_includes/_team_profile.html
@@ -26,7 +26,12 @@
 {% endif %}
 <div class="medium-4 columns{{ row_align }}{{ last_row_item }}">
 <div class="team-member">
+{% if member.alt_text %}  
+<img src="{{ site.filesurl }}/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="{{ member.alt_text }}">
+{% else %}
 <img src="{{ site.filesurl }}/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="Headshot of {{ member.name}}, {{ member.position }}">
+{% endif %}
+
 <h4>{{ member.name }}</h4>
 <p class="text-muted">
 {{ member.position }}<br>


### PR DESCRIPTION
Creates options for Core Team alt text to either use default alt text ("Headshot of name, position") or to define custom alt text in the data file. 