### PR TITLE
Update Genomic CAC members

### DIFF
--- a/_data/curriculum_advisors.yml
+++ b/_data/curriculum_advisors.yml
@@ -43,20 +43,20 @@
   curriculum: genomics
   position: member
 
+- name: Graeme Grimes
+  github: ggrimes
+  curriculum: genomics
+  position: member
+
 - name: Jeff Hollister
   github: jhollist
   curriculum: geospatial
   position: chair
 
-- name: Ming Tang
-  github: crazyhottommy
-  curriculum: genomics
-  position: chair
-
 - name: Naupaka Zimmerman
   github: naupaka
   curriculum: genomics
-  position: member
+  position: chair
 
 - name: Jeff Hollister
   github: jhollist


### PR DESCRIPTION
Remove Ming Tang, make Naupaka chair, add Graeme Grimes for Genomics CAC.
