### PR TITLE
remove twitter sidebar from blog page

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -35,7 +35,4 @@ permalink: "blog/"
     {% endfor %}
   </div>
 
-  <div class="medium-4 columns t30">
-    {% include _sidebar.html %}
-  </div><!-- /.medium-5.columns -->
 </div>


### PR DESCRIPTION
Following this [slack conversation](https://swcarpentry.slack.com/archives/GGE8UA04X/p1688664686113439) (private link), we are removing the Twitter sidebar from the blog page.  