### PR TITLE
darker gray for accessibility

### DIFF
--- a/_sass/_01_settings_colors.scss
+++ b/_sass/_01_settings_colors.scss
@@ -60,7 +60,7 @@ $grey-1: #E4E4E4;
 $grey-2: #D7D7D7;
 $grey-3: #CBCBCB;
 $grey-4: #BEBEBE;
-$grey-5: #A4A4A4;
+$grey-5: #5A585D;
 $grey-6: #979797;
 $grey-7: #8B8B8B;
 $grey-8: #7E7E7E;


### PR DESCRIPTION
Changes text including the meta-text (date, authors) on blog post listing to be a darker gray in the interest of accessibility. As recommended by @brynnelliott