### PR TITLE
deprecate lesson infrastructure committee

### DIFF
--- a/pages/lesson-infra.md
+++ b/pages/lesson-infra.md
@@ -5,22 +5,22 @@ permalink: /lesson-infra/
 excerpt: Maintainers for Carpentries lesson and workshop templates and documentation.
 ---
 
-The Lesson Infrastructure Committee went into hiatus in March 2020 due to the pandemic. We are in the process of performing a retrospective of this committee to identify strengths and areas of improvement. These findings will help us guide the formation of the next committee to ensure that it aligns with our core values. Continue reading to learn more about the past work of this committee.
+**The Lesson Infrastructure Committee went into hiatus in March 2020 due to the pandemic and is not currently active. Read more in this blog post: [The Lesson Infrastructure Commitee: Past, Present, and Future](https://carpentries.org/blog/2021/12/lesson-infrastructure-committee/).**
 
-Members of the Lesson Infrastructure Committee serve as Maintainers for The Carpentries lesson template and its documentation, 
+Members of the Lesson Infrastructure Committee served as Maintainers for The Carpentries lesson template and its documentation, 
 as well as for The Carpentries workshop template.
 
 _Our Goal:_    
 To maintain and update lesson and workshop templates for The Carpentries.
 
 _Our Approach:_    
-We do this by conducting meetings where we review current issues and plan updates. Minutes and other information is stored in 
+We did this by conducting meetings where we reviewed current issues and plan updates. Minutes and other information are stored in 
 this [GitHub repo](https://github.com/carpentries/lesson-infrastructure).
 
 _Our Structure:_    
-We have monthly meetings. See our [etherpad](https://pad.carpentries.org/infrastructure-subcommittee) for meeting times and agenda items.
+We held monthly meetings. See our [etherpad](https://pad.carpentries.org/infrastructure-subcommittee) for meeting times and agenda items.
 
-_Our Membership:_    
+_Our Past Membership:_    
 
 - Maxim Belkin
 - Sarah Brown
@@ -31,5 +31,3 @@ _Our Membership:_
 - Raniere Silva
 - Naupaka Zimmerman
 
-_Contacting the Committee_   
-Please send an email to [François Michonneau](mailto:francois@carpentries.org) or [Zhian Kamvar](zkamvar@carpentries.org).


### PR DESCRIPTION
Per conversation with @zkamvar ([private Slack link](https://carpentries.slack.com/archives/G01UN8NBDT6/p1693256860502339?thread_ts=1693251226.098769&cid=G01UN8NBDT6)) this PR notes the committee is no longer active, links to a blog post, and changes other language to past tense.