### PR TITLE
fix broken link for Instructor Training Calendar

### DIFF
--- a/pages/become-instructor.md
+++ b/pages/become-instructor.md
@@ -60,7 +60,7 @@ Group pricing for Instructor Training is listed below.
 The Open Instructor Training Program is a Carpentries-sponsored program in which individual applicants may be invited to receive training at no cost. Applications are scored and accepted on a rolling basis in order of scoring. This program is not for groups; multiple individuals from a single institution or cohort may be considered but will not be admitted simultaneously. [Apply to our Open Instructor Training Program]({{site.instructor_training_app}}).
 
 ## Group Training & Priority Access Fees
-Individuals and organisations may pay a fee to gain access to Instructor Training. Once invoiced, we will create a unique registration code that trainees can use to access registration for any event on our quarterly [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar/index.html). 
+Individuals and organisations may pay a fee to gain access to Instructor Training. Once invoiced, we will create a unique registration code that trainees can use to access registration for any event on our quarterly [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar#upcoming-instructor-training). 
 
 |                     | Instructor Training Seat Fee (USD) |
 |---------------------|------------------------------------|


### PR DESCRIPTION
Hi, 
Thanks for maintaining the website of the Carpentries : )
I spotted a broken link regarding the Instructor Training Calendar, that I fixed with a link to the dedicated section.
Hope that helps!
Best, 
