### PR TITLE
Remove Facebook; replace Twitter with Mastodon

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -116,8 +116,8 @@
     url: "/newsletter/"
   - title: "Carpentries Podcast"
     url: "/podcasts/"
-  - title: "Twitter"
-    url: "https://twitter.com/thecarpentries/"
+  - title: "Mastodon"
+    url: "https://hachyderm.io/@thecarpentries"
 
 - title: "Donate"
   url: "http://give.communityin.org/TheCarpentries"

--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -8,16 +8,6 @@
   class: fa-mastodon
   title: ""
 
-- name: Twitter
-  url: https://twitter.com/thecarpentries
-  class: fa-twitter
-  title: ""
-
-- name: Facebook
-  url: http://www.facebook.com/carpentries
-  class: fa-facebook
-  title: ""
-
 - name: Slack
   url: https://slack-invite.carpentries.org/
   class: fa-slack
@@ -32,25 +22,3 @@
   url: https://www.linkedin.com/company/the-carpentries/
   class: fa-linkedin
   title: ""
-
-
-
-# - name: Soundcloud
-#   url: http://soundcloud.com/
-#   class: icon-soundcloud
-#   title: ""
-
-# - name: Instagram
-#   url: http://instagram.com/
-#   class: icon-instagram
-#   title: ""
-
-# - name: Pinterest
-#   url: http://www.pinterest.com/
-#   class: icon-pinterest
-#   title: ""
-
-# - name: Xing
-#   url: https://www.xing.com/profile/
-#   class: icon-xing
-#   title: Xing Profil

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -65,15 +65,15 @@
 	{% if site.socialmedia.facebook %}<meta property="article:author" content="https://www.facebook.com/{{ site.socialmedia.facebook }}">{% endif %}
 
 
-	{% if site.socialmedia.twitter %}
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary">
+	{% if site.socialmedia.twitter %}
 	<meta name="twitter:site" content="{{ site.socialmedia.twitter }}">
 	<meta name="twitter:creator" content="{{ site.socialmedia.twitter }}">
+	{% endif %}
 	<meta name="twitter:title" content="{{ title }}">
 	<meta name="twitter:description" content="{{ description }}">
 	{% if page.image.title %}<meta name="twitter:image" content="{{ site.urlimg }}/{{ page.image.title }}">{% endif %}
-	{% endif %}
 
 	<link type="text/plain" rel="author" href="{{ url}}/humans.txt">
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -44,19 +44,16 @@ Individuals and organisations are welcome to <a href="{{site.fundraising_link}}"
 #### What Information is Where?
 
 What is common across The Carpentries - the Code of Conduct, assessment, governance, instructor training, our privacy policy - will be found through this site, while specific Lesson Program material, will remain on the individual [Software Carpentry](https://software-carpentry.org/), [Data Carpentry](http://www.datacarpentry.org/), and <a href="https://librarycarpentry.org/">Library Carpentry</a> sites. We will increasingly post on The Carpentries [blog]({{site.url}}/blog/), rather than to individual Carpentries blog sites, and we will tweet
-through our [Carpentries Twitter](https://twitter.com/thecarpentries) account. 
+through our [Carpentries Mastodon][mastodon] account.
 
-  
-#### Join Us!
-            
-Organisations are encouraged to <a href="{{site.url}}/membership/">join us as contributing members to support the work we do.</a> We 
-welcome <a href="{{site.url}}/volunteer/">new people</a> to our community. We have 
-<a href="{{site.url}}/volunteer/">many ways to engage</a>, including The Carpentries <a href="https://twitter.com/thecarpentries">Twitter</a> feed, our <a href="{{site.slack_invite}}">Slack</a> channel, 
+#### Join Us
+
+Organisations are encouraged to <a href="{{site.url}}/membership/">join us as contributing members to support the work we do.</a> We
+welcome <a href="{{site.url}}/volunteer/">new people</a> to our community. We have
+<a href="{{site.url}}/volunteer/">many ways to engage</a>, including The Carpentries [Mastodon][mastodon] feed, our <a href="{{site.slack_invite}}">Slack</a> channel,
 subscribing to <em>Carpentries Clippings</em>, our twice-monthly <a href="{{site.url}}/newsletter/">newsletter</a>, following our [Facebook](https://www.facebook.com/carpentries/) page, and by joining some of our <a href="https://carpentries.topicbox.com/groups">email lists</a>.
 
-We announce a lot of what we do via our Twitter feed. [Follow us on Twitter](https://twitter.com/thecarpentries). 
-
-You can also follow the [Software Carpentry](https://twitter.com/swcarpentry), [Data Carpentry](https://twitter.com/datacarpentry), and [Library Carpentry](https://twitter.com/LibCarpentry) Twitter feeds. 
+We announce a lot of what we do via our Mastodon feed. [Follow us on Mastodon][mastodon].
 
 #### Referencing The Carpentries
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -46,7 +46,7 @@ Individuals and organisations are welcome to <a href="{{site.fundraising_link}}"
 What is common across The Carpentries - the Code of Conduct, assessment, governance, instructor training, our privacy policy - will be found through this site, while specific Lesson Program material, will remain on the individual [Software Carpentry](https://software-carpentry.org/), [Data Carpentry](http://www.datacarpentry.org/), and <a href="https://librarycarpentry.org/">Library Carpentry</a> sites. We will increasingly post on The Carpentries [blog]({{site.url}}/blog/), rather than to individual Carpentries blog sites, and we will tweet
 through our [Carpentries Mastodon][mastodon] account.
 
-#### Join Us
+#### Join Us!
 
 Organisations are encouraged to <a href="{{site.url}}/membership/">join us as contributing members to support the work we do.</a> We
 welcome <a href="{{site.url}}/volunteer/">new people</a> to our community. We have

--- a/pages/about.md
+++ b/pages/about.md
@@ -69,3 +69,6 @@ We appreciate being mentioned in the acknowledgments sections of papers, theses,
 Software Carpentry, Data Carpentry, and Library Carpentry have been featured in many publications, and some members of The Carpentries community have written materials about our workshops, our history, and our impact. See our <a href="{{site.url}}/citations/">citations</a> page for a list. Comprehensive reports about our impact can be found in our <a href="{{site.url}}/assessment/">assessment</a> section. 
 
 Do you know about other works that should be listed here? If so, please email <a href="mailto:{{site.contact}}">{{site.contact}}</a> to let us know.
+
+<!-- URLs -->
+[mastodon]: https://hachyderm.io/@thecarpentries

--- a/pages/carp-con-tf.md
+++ b/pages/carp-con-tf.md
@@ -18,5 +18,4 @@ CarpentryCon is the key biennial community-building and networking event in The 
 
 ## Contacting the Task Force
 
-You can email the Task Force at [{{site.carpentrycon_contact}}](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack]({{site.slack_invite}}) or follow the event on [Twitter](https://twitter.com/CarpentryCon). 
-
+You can email the Task Force at [{{site.carpentrycon_contact}}](mailto:{{site.carpentrycon_contact}}). You can also join the `#carpentrycon` channel on The Carpentries [Slack]({{site.slack_invite}}) or follow posts tagged #CarpentryCon by The Carpentries on [Mastodon](https://hachyderm.io/@thecarpentries).

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -38,6 +38,6 @@ USA
 
 <div class="medium-3 columns"> <strong>on Mastodon:</strong>
 <br>
-<a rel="me" href="https://fosstodon.org/@thecarpentries"><i class="fab fa-mastodon"></i>@TheCarpentries@fosstodon.org</a>
+<a rel="me" href="https://hachyderm.io/@thecarpentries"><i class="fab fa-mastodon"></i>@TheCarpentries@hachyderm.io</a>
 
    </div>

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -41,22 +41,3 @@ USA
 <a rel="me" href="https://fosstodon.org/@thecarpentries"><i class="fab fa-mastodon"></i>@TheCarpentries@fosstodon.org</a>
 
    </div>
-
-    
-<div class="medium-3 columns"> <strong>on Twitter:</strong>
-<br><br>
-<a href="https://twitter.com/thecarpentries?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @thecarpentries</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-<a href="https://twitter.com/datacarpentry?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @datacarpentry</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-<a href="https://twitter.com/swcarpentry?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @swcarpentry</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-<a href="https://twitter.com/libcarpentry?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @libcarpentry</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-
-   </div>
-
-
-
-
-


### PR DESCRIPTION
- [x]  Remove Twitter and Facebook icons from the website footer
- [x] There is a "Twitter" dropdown from the "Connect" main navigation menu. This needs to be changed to "Mastodon" and redirected to this URL: https://hachyderm.io/@thecarpentries
- [x] Sweep for "Twitter" on the rest of the website and update as appropriate

@acrall what's happening to the CarpentryCon Twitter referenced on this page? https://carpentries.org/carp-con-tf/