### PR TITLE
bump CLDT events from workshops list

### DIFF
--- a/_includes/workshop_table.md
+++ b/_includes/workshop_table.md
@@ -10,6 +10,8 @@ Click on an individual event to learn more about that event, including contact i
      
      {% if tags contains "ttt" %}
          {% continue %}
+     {% elsif tags contains "cldt" %}
+         {% continue %}
      {% elsif tags contains "swc" %}
          {% assign workshop_type = "swc" %}
      {% elsif tags contains "dc" %}


### PR DESCRIPTION
Adds a line to move on in loop (`continue`) if tag is CLDT, just as it does if tag is TTT.  