### PR TITLE
add ability to manually run build/deploy action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,8 @@ on:
     branches: main
   schedule:
     - cron: '30 */6 * * *'
+  workflow_dispatch:
+  
 
 jobs:
   build-website:


### PR DESCRIPTION
Similar to what we did here in the feeds repo (https://github.com/carpentries/feeds.carpentries.org/pull/80) this PR adds a button to allow us to manually run this workflow.