### PR TITLE
Test pinning gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ source 'https://rubygems.org'
 gem 'faraday', '0.17.3'
 
 group :jekyll_plugins do
-  gem 'github-pages'
+  gem 'github-pages', '206'
   gem 'jekyll-get-json', "~> 1.0.0"
+  gem 'jekyll', '3.8.7'
 end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
     gem 'webrick', '>= 1.6.1'


### PR DESCRIPTION
Locally, pinning the github-pages and jekyll versions to previous working versions seems to fix the excerpt problem
