### PR TITLE
convert members page from md to html

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -10,12 +10,14 @@ permalink: "/members/"
 {% assign silver_members = site.data.members | where: "variant", "silver" | sort: "name" %}
 {% assign bronze_members = site.data.members | where: "variant", "bronze" | sort: "name" %}
 
-A Member Organisation is an organisation that has made a financial commitment to
-the growth and sustainability of The Carpentries and is building local capacity for training. See more on [becoming a Member Organisation]({% link pages/membership.html %}).
+<p>
+    A Member Organisation is an organisation that has made a financial commitment to
+    the growth and sustainability of The Carpentries and is building local capacity for training. See more on <a href="/membership">becoming a Member Organisation</a>.
+</p>
 
-View our [current member sites on a map]({% link pages/members-map.html %}).
+<p>View our <a href="/members-map">current member sites on a map</a>.</p>
 
-### Platinum Member Organisations
+<h3>Platinum Member Organisations</h3>
 
 <ul>
 {% for member in platinum_members %}
@@ -31,47 +33,47 @@ View our [current member sites on a map]({% link pages/members-map.html %}).
 </ul>
 
 
-### Gold Member Organisations
+<h3>Gold Member Organisations</h3>
 
 <ul>
 {% for member in gold_members %}
 <li>
     <a href = "https://{{ member.domain }}">{{ member.name }}</a>
     {% if member.country == "" %}
-        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}}>
     {% else %}
-        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}}>
     {% endif %}
 </li>
 {% endfor %}
 </ul>
 
 
-### Silver Member Organisations
+<h3>Silver Member Organisations</h3>
 
 <ul>
 {% for member in silver_members %}
 <li>
     <a href = "https://{{ member.domain }}">{{ member.name }}</a>
     {% if member.country == "" %}
-        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}}>
     {% else %}
-        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}}>
     {% endif %}
 </li>
 {% endfor %}
 </ul>
 
-### Bronze Member Organisations
+<h3>Bronze Member Organisations</h3>
 
 <ul>
 {% for member in bronze_members %}
 <li>
     <a href = "https://{{ member.domain }}">{{ member.name }}</a>
     {% if member.country == "" %}
-        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/w3.svg" alt={{member.country}} title={{member.country}}>
     {% else %}
-        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}} />
+        <img width="24" src="/files/flags/{{ member.country | downcase }}.svg" alt={{member.country}} title={{member.country}}>
     {% endif %}
 </li>
 {% endfor %}
@@ -87,4 +89,3 @@ View our [current member sites on a map]({% link pages/members-map.html %}).
         images[i].alt = fullName;
     }
 </script>
-

--- a/pages/regional_coordinators.html
+++ b/pages/regional_coordinators.html
@@ -10,7 +10,7 @@ permalink: /regionalcoordinators/
 Around the world, Carpentries workshops are organized by a team of Regional Coordinators.
 
 <p>
-Our Workshop Administrator, Daneille Sieh, manages workshops in most of the world. In some parts of the world, local Carpenters support managing local workshops and building local communities. They work with our <a href="{% link pages/members.md %}">member sites</a> or as volunteers.
+Our Workshop Administrator, Daneille Sieh, manages workshops in most of the world. In some parts of the world, local Carpenters support managing local workshops and building local communities. They work with our <a href="{% link pages/members.html %}">member sites</a> or as volunteers.
 </p>
 
 <p>


### PR DESCRIPTION
This PR converts the members page from md to html.
With mixed md and html content in the md page, characters like angle brackets were not being recognized as html identifiers and got rendered as plain text via `&lt;` or `&gt;`.