### PR TITLE
Cleanup blog tags

### DIFF
--- a/_posts/2013/01/2013-01-14-montreal-in-january.html
+++ b/_posts/2013/01/2013-01-14-montreal-in-january.html
@@ -4,7 +4,7 @@ authors: ["Ross Dickson"]
 title: Montreal in January
 date: 2013-01-14
 time: "09:00:00"
-tags: ["McGill University", "Workshop", "Report", "Reflection", "Software Carpentry"]
+tags: ["McGill University", "Workshops", "Report", "Reflection", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/01/2013-01-16-uchicago-in-january.html
+++ b/_posts/2013/01/2013-01-16-uchicago-in-january.html
@@ -4,7 +4,7 @@ authors: ["Anthony Scopatz"]
 title: University of Chicago in January
 date: 2013-01-16
 time: "09:00:00"
-tags: ["University of Chicago", "Workshop", "Report", "Reflection", "Software Carpentry"]
+tags: ["University of Chicago", "Workshops", "Report", "Reflection", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/01/2013-01-30-boot-camp-at-mozilla.html
+++ b/_posts/2013/01/2013-01-30-boot-camp-at-mozilla.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: A Bootcamp at Mozilla
 date: 2013-01-30
 time: "09:00:00"
-tags: ["Mozilla (Toronto)", "Workshop", "Report", "Reflection", "Software Carpentry"]
+tags: ["Mozilla (Toronto)", "Workshops", "Report", "Reflection", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/01/2013-01-30-ubc-swc-r.html
+++ b/_posts/2013/01/2013-01-30-ubc-swc-r.html
@@ -4,7 +4,7 @@ authors: ["Ted Hart"]
 title: Teaching R at UBC
 date: 2013-01-30
 time: "10:00:00"
-tags: ["University of British Columba", "Workshop", "Report", "Reflection", "Software Carpentry"]
+tags: ["University of British Columba", "Workshops", "Report", "Reflection", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-03-a-short-report-from-tuebingen.html
+++ b/_posts/2013/02/2013-02-03-a-short-report-from-tuebingen.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: A Short Report from Tuebingen
 date: 2013-02-03
 time: "09:00:00"
-tags: ["Max Planck Institute - Tuebingen", "Workshop", "Report", "Software Carpentry"]
+tags: ["Max Planck Institute - Tuebingen", "Workshops", "Report", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-08-macquarie-went-well.html
+++ b/_posts/2013/02/2013-02-08-macquarie-went-well.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: Macquarie Went Well
 date: 2013-02-08
 time: "09:00:00"
-tags: ["Macquarie Universty", "Workshops", "Report", "Feedback", "Software Carpentry"]
+tags: ["Macquarie University", "Workshops", "Report", "Feedback", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-08-macquarie-went-well.html
+++ b/_posts/2013/02/2013-02-08-macquarie-went-well.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: Macquarie Went Well
 date: 2013-02-08
 time: "09:00:00"
-tags: ["Macquarie Universty", "Workshop", "Report", "Feedback", "Software Carpentry"]
+tags: ["Macquarie Universty", "Workshops", "Report", "Feedback", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-11-ubc-went-well.html
+++ b/_posts/2013/02/2013-02-11-ubc-went-well.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: UBC Went Well
 date: 2013-02-11
 time: "10:00:00"
-tags: ["University of British Columba", "Workshop", "Feedback", "Software Carpentry"]
+tags: ["University of British Columba", "Workshops", "Feedback", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-14-amsterdam-open.html
+++ b/_posts/2013/02/2013-02-14-amsterdam-open.html
@@ -4,7 +4,7 @@ authors: ["Amy Brown"]
 title: Registration for Amsterdam Bootcamp is Open
 date: 2013-02-14
 time: "09:00:00"
-tags: ["Vrije Universiteit", "Workshop", "Software Carpentry"]
+tags: ["Vrije Universiteit", "Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-14-more-news-from-the-uk.html
+++ b/_posts/2013/02/2013-02-14-more-news-from-the-uk.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: More News from the UK
 date: 2013-02-14
 time: "10:00:00"
-tags: ["Community", "Workshop", "Software Carpentry"]
+tags: ["Community", "Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2013/02/2013-02-15-wrapping-up-in-melbourne.html
+++ b/_posts/2013/02/2013-02-15-wrapping-up-in-melbourne.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: Wrapping Up in Melbourne
 date: 2013-02-15
 time: "10:00:00"
-tags: ["University of Melbourne", "Workshop", "Feedback", "Software Carpentry"]
+tags: ["University of Melbourne", "Workshops", "Feedback", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2014/12/2014-12-05-new-accessibility-guidelines.html
+++ b/_posts/2014/12/2014-12-05-new-accessibility-guidelines.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "New Accessibility Guidelines"
 date: 2014-12-05
 time: "16:05:00"
-tags: ["Accessiblity", "Workshops", "Software Carpentry"]
+tags: ["Accessibility", "Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2014/12/2014-12-15-guiding-data-carpentry.md
+++ b/_posts/2014/12/2014-12-15-guiding-data-carpentry.md
@@ -7,7 +7,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal"]
 redirect_from: /blog/guiding-data-carpentry/
 --- 

--- a/_posts/2015/02/2015-02-02-workshops-in-march-at-lbl.html
+++ b/_posts/2015/02/2015-02-02-workshops-in-march-at-lbl.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Workshops in March at Lawrence Berkeley Lab"
 date: 2015-02-02
 time: "09:30:00"
-tags: ["Workshops", "Instructor Training", "Lawrence Berkeley Lab", "Software Carpentry"]
+tags: ["Workshops", "Instructor Training", "Lawrence Berkeley National Laboratory", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2016/06/2016-06-06-library-carpentry-sprint.md
+++ b/_posts/2016/06/2016-06-06-library-carpentry-sprint.md
@@ -6,7 +6,7 @@ date: 2016-06-06
 time: "00:00:01"
 redirect_from:
   - /blog/2016/06/LibrarCarpentrysprint.html
-tags: ["sprints", "hackathons", "Data Carpentry", "Software Carpentry"]
+tags: ["Sprints", "Hackathons", "Data Carpentry", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2016/11/2016-11-02-rstudio-instructors.md
+++ b/_posts/2016/11/2016-11-02-rstudio-instructors.md
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "RStudio Training and Consulting Directory"
 date: 2016-11-02
 time: "14:00:00"
-tags: ["R Studio", "Jobs", "Software Carpentry"]
+tags: ["RStudio", "Jobs", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2016/12/2016-12-14-niwa-workshop.md
+++ b/_posts/2016/12/2016-12-14-niwa-workshop.md
@@ -4,7 +4,7 @@ authors: ["Wolfgang Hayek", "Aleksandra Pawlik"]
 title: "Software Carpentry workshop in severe conditions"
 date: 2016-12-19
 time: "15:00:00"
-tags: ["workshops", "Software Carpentry"]
+tags: ["Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2016/12/2016-12-22-instructor-training-intercontinental.md
+++ b/_posts/2016/12/2016-12-22-instructor-training-intercontinental.md
@@ -4,7 +4,7 @@ authors: ["Aleksandra Pawlik"]
 title: "Instructor Traininig Intercontinental"
 date: 2016-12-22
 time: "15:00:00"
-tags: ["instructor training", "Software Carpentry"]
+tags: ["Instructor Training", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/05/2017-05-17-lc-Portland-Boston.md
+++ b/_posts/2017/05/2017-05-17-lc-Portland-Boston.md
@@ -4,7 +4,7 @@ authors: ["Juliane Schneider"]
 title: "Three Instructors, Two Coasts and One Spatula"
 date: 2017-05-17
 time: "10:00:00"
-tags: ["Instructor training","Library Carpentry","Workshops", "Software Carpentry"]
+tags: ["Instructor Training","Library Carpentry","Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/06/2017-06-08-lc-sprint.md
+++ b/_posts/2017/06/2017-06-08-lc-sprint.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "The Endless Sprint"
 date: 2017-06-07
 time: "00:00:00"
-tags: ["hackathons", "Library Carpentry", "Software Carpentry"]
+tags: ["Hackathons", "Library Carpentry", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/06/2017-06-26-ws-admin.md
+++ b/_posts/2017/06/2017-06-26-ws-admin.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Job Posting: Workshop Administrator"
 date: 2017-06-26
 time: "06:00:00"
-tags: ["Job posting", "Staff", "Workshops", "Software Carpentry"]
+tags: ["Jobs", "Staff", "Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/07/2017-07-10-assess_report.md
+++ b/_posts/2017/07/2017-07-10-assess_report.md
@@ -5,7 +5,7 @@ title: "Analysis of Software Carpentry Workshop Impact"
 date: 2017-07-10
 time: "08:00:00"
 authors: ["Kari L. Jordan"]
-tags: ["surveys", "workshops", "impact", "assessment", "Software Carpentry"]
+tags: ["Surveys", "Workshops", "Impact", "Assessment", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/07/2017-07-11-instructor-training-bonanza.md
+++ b/_posts/2017/07/2017-07-11-instructor-training-bonanza.md
@@ -5,7 +5,7 @@ title: "Help Update the Instructor Training Materials"
 date: 2017-07-11
 time: "08:00:00"
 authors: ["Erin Becker"]
-tags: ["curriculum", "Software Carpentry"]
+tags: ["Curriculum", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/07/2017-07-25-write-blog.md
+++ b/_posts/2017/07/2017-07-25-write-blog.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Keep Calm and Write a Blog Post"
 date: 2017-07-25
 time: "06:00:00"
-tags: [ "Blog posts", "Community news", "Workshops", "Reports", "Software Carpentry"]
+tags: [ "Blog posts", "Community News", "Workshops", "Reports", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/08/2017-08-14-inst-curr-update.md
+++ b/_posts/2017/08/2017-08-14-inst-curr-update.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Instructor Curriculum Updated"
 date: 2017-08-14
 time: "16:00"
-tags: ["Instructor training", "Hackathons", "Bug BBQ", "Software Carpentry"]
+tags: ["Instructor Training", "Hackathons", "Bug BBQ", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/08/2017-08-17-lightness.md
+++ b/_posts/2017/08/2017-08-17-lightness.md
@@ -4,7 +4,7 @@ authors: ["Juliane Schneider"]
 title: "The Totally Bearable Lightness of Being an Instructor ... So Finish that Training!"
 date: 2017-08-17
 time: "00:00"
-tags: ["Instructor training", "Software Carpentry"]
+tags: ["Instructor Training", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/08/2017-08-31-WaxingPoetical.md
+++ b/_posts/2017/08/2017-08-31-WaxingPoetical.md
@@ -4,7 +4,7 @@ authors: ["Brian Ballsun-Stanton"]
 title: "Waxing poetical in a Software Carpentry workshop"
 date: 2017-08-31
 time: "20:00:00"
-tags: ["Workshops", "Macquarie University", "Reflections", "Software Carpentry"]
+tags: ["Workshops", "Macquarie University", "Reflection", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/09/2017-09-19-new-staff-intro_dc.md
+++ b/_posts/2017/09/2017-09-19-new-staff-intro_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal", "Elizabeth Williams", "Karen Word"]
 redirect_from: /blog/new-staff-intro/
 --- 

--- a/_posts/2017/09/2017-09-19-rfc_dc.md
+++ b/_posts/2017/09/2017-09-19-rfc_dc.md
@@ -6,7 +6,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kate Hertweck"]
 redirect_from: /blog/rfc/
 --- 

--- a/_posts/2017/09/2017-09-21-davis-inperson.md
+++ b/_posts/2017/09/2017-09-21-davis-inperson.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/davis-inperson/
 --- 

--- a/_posts/2017/09/2017-09-22-lat-am-lessons.md
+++ b/_posts/2017/09/2017-09-22-lat-am-lessons.md
@@ -7,7 +7,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Heladia Salgado", "Paula Andrea Martinez", "Sue McClatchy"]
 --- 
 

--- a/_posts/2017/10/2017-10-03-new-trainer-round.md
+++ b/_posts/2017/10/2017-10-03-new-trainer-round.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Karen Word"]
 redirect_from: /blog/new-trainer-round/
 --- 

--- a/_posts/2017/10/2017-10-05-mentoring-round-2_dc.md
+++ b/_posts/2017/10/2017-10-05-mentoring-round-2_dc.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan","Belinda Weaver"]  
 redirect_from: /blog/mentoring-round-2/
 --- 

--- a/_posts/2017/10/2017-10-10-wrap-cycle-ganymede.md
+++ b/_posts/2017/10/2017-10-10-wrap-cycle-ganymede.md
@@ -9,7 +9,7 @@ Categories:
  - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Carpentry Staff"]
 redirect_from: /blog/wrap-cycle-ganymede/
 --- 

--- a/_posts/2017/10/2017-10-11-mentorship-wrap-up.md
+++ b/_posts/2017/10/2017-10-11-mentorship-wrap-up.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Erin Becker", "Kari L. Jordan", "Tracy Teal", "Christina Koch"] 
 
 redirect_from: /blog/mentorship-wrap-up/

--- a/_posts/2017/10/2017-10-16-fave-tools_dc.md
+++ b/_posts/2017/10/2017-10-16-fave-tools_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/fave-tools/
 --- 

--- a/_posts/2017/10/2017-10-18-long-term-survey-results_dc.md
+++ b/_posts/2017/10/2017-10-18-long-term-survey-results_dc.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan", "Tracy Teal", "Erin Becker", "Karen Word"]
 redirect_from: /blog/long-term-survey-results/
 --- 

--- a/_posts/2017/10/2017-10-23-call-for-candidates-joint-board.md
+++ b/_posts/2017/10/2017-10-23-call-for-candidates-joint-board.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Karen Cranston"]
 
 redirect_from: /blog/call-for-candidates-joint-board/

--- a/_posts/2017/10/2017-10-30-people-fave-tools.md
+++ b/_posts/2017/10/2017-10-30-people-fave-tools.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/people-fave-tools/
 --- 

--- a/_posts/2017/10/2017-10-30-survey-focus-group-update.md
+++ b/_posts/2017/10/2017-10-30-survey-focus-group-update.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan", "Stephen Childs", "Alycia Crall", "Reshama Shaikh", "Aleksandra Nenadic", "Karen Word", "Louisa Bells"]
 
 redirect_from: /blog/survey-focus-group-update/

--- a/_posts/2017/10/2017-11-29-favorites.md
+++ b/_posts/2017/10/2017-11-29-favorites.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "People's Favorite Tools"
 date: 2017-11-29
 time: "09:00:00"
-tags: ["Python", "IPython", "Jupyter", "Teaching", "R", "Git", "GitHub", "Videoconferencing", "emacs", "RStudio", "rasterio", "Software Carpentry"]
+tags: ["Python", "IPython", "Jupyter", "Teaching", "R", "Git", "GitHub", "Videoconferencing", "Emacs", "RStudio", "rasterio", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/11/2017-11-03-carpcon-announce.md
+++ b/_posts/2017/11/2017-11-03-carpcon-announce.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Fotis Psomopoulos", "Belinda Weaver"]
 redirect_from: /blog/carpcon-announce/
 --- 

--- a/_posts/2017/11/2017-11-03-fm-fave-tool.md
+++ b/_posts/2017/11/2017-11-03-fm-fave-tool.md
@@ -4,7 +4,7 @@ authors: ["Francesco Montanari"]
 title: "My Favorite Tool - Emacs"
 date: 2017-11-03
 time: "18:00:00"
-tags: ["Emacs", "Text editors", "Software Carpentry"]
+tags: ["Emacs", "Text Editors", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/11/2017-11-06-library-carpentry-cdl_dc.md
+++ b/_posts/2017/11/2017-11-06-library-carpentry-cdl_dc.md
@@ -9,7 +9,7 @@ Categories:
 comments: true
 show_meta: true
 date: 2017-11-06
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["John Chodacki"]
 --- 
 

--- a/_posts/2017/11/2017-11-07-maintainer-apply.md
+++ b/_posts/2017/11/2017-11-07-maintainer-apply.md
@@ -9,7 +9,7 @@ Categories:
 comments: true
 show_meta: true
 date: 2017-11-07
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Erin Becker"]
 redirect_from: /blog/maintainer-apply/
 --- 

--- a/_posts/2017/11/2017-11-09-gabon-bioinformatics.md
+++ b/_posts/2017/11/2017-11-09-gabon-bioinformatics.md
@@ -4,7 +4,7 @@ authors: ["Nicola Anthony", "Katy Morgan", "Courtney Miller", "Anelda van der Wa
 title: "CAB-Alliance Bioinformatics Workshop in Franceville, Gabon"
 date: 2017-11-09
 time: "09:00:00"
-tags: ["Gabon", "Africa", "Bioinformatics", "Workshop", "Software Carpentry"]
+tags: ["Gabon", "Africa", "Bioinformatics", "Workshops", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/11/2017-11-13-online-meetings.md
+++ b/_posts/2017/11/2017-11-13-online-meetings.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Running effective online meetings with Zoom (or Google Hangouts, or ...)"
 date: 2017-11-08
 time: "00:00:13"
-tags: ["Online meetings", "Zoom", "Software Carpentry"]
+tags: ["Online Meetings", "Zoom", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/11/2017-11-20-16s-dc.md
+++ b/_posts/2017/11/2017-11-20-16s-dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Bianca Peterson"]
 redirect_from: /blog/16s-dc/
 --- 

--- a/_posts/2017/11/2017-11-20-mentoring-co-chair_dc.md
+++ b/_posts/2017/11/2017-11-20-mentoring-co-chair_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Marian Schmidt", "Jamie Hadwin"]
 redirect_from: /blog/mentoring-co-chair/
 --- 

--- a/_posts/2017/11/2017-11-21-genomics-lesson-release.md
+++ b/_posts/2017/11/2017-11-21-genomics-lesson-release.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Erin Becker"]
 redirect_from: /blog/genomics-lesson-release/
 --- 

--- a/_posts/2017/11/2017-11-21-meet-candidates.md
+++ b/_posts/2017/11/2017-11-21-meet-candidates.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/meet-candidates/
 --- 

--- a/_posts/2017/11/2017-11-28-sare-favorite.md
+++ b/_posts/2017/11/2017-11-28-sare-favorite.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Robert Sare"]
 --- 
 

--- a/_posts/2017/12/2017-12-03-satRday-cape-town-2018.md
+++ b/_posts/2017/12/2017-12-03-satRday-cape-town-2018.md
@@ -4,7 +4,7 @@ authors: ["Jon Calder"]
 title: "satRday Cape Town 2018"
 date: 2017-12-03
 time: "06:00:00"
-tags: ["conferences", "workshops", "r", "satRday", "Software Carpentry"]
+tags: ["Conferences", "Workshops", "R", "satRday", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/12/2017-12-04-lesson_infra_mtg.md
+++ b/_posts/2017/12/2017-12-04-lesson_infra_mtg.md
@@ -7,7 +7,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Raniere Silva"]
 redirect_from: /blog/lesson_infra_mtg/
 --- 

--- a/_posts/2017/12/2017-12-04-opencon-berlin.md
+++ b/_posts/2017/12/2017-12-04-opencon-berlin.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/opencon-berlin/
 --- 

--- a/_posts/2017/12/2017-12-05-for-the-win.md
+++ b/_posts/2017/12/2017-12-05-for-the-win.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Celebrate the Wins of 2017: Join the year's final community call"
 date: 2017-12-05
 time: "00:00:00"
-tags: [ "Community calls", "Software Carpentry"]
+tags: [ "Community Calls", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2017/12/2017-12-07-geospatial-socsci.md
+++ b/_posts/2017/12/2017-12-07-geospatial-socsci.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: [Erin Becker]
 redirect_from: /blog/geospatial-socsci/
 --- 

--- a/_posts/2017/12/2017-12-11-data-science-assessment-challenges.md
+++ b/_posts/2017/12/2017-12-11-data-science-assessment-challenges.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Marianne Corvellec", "Kari L. Jordan"]
 
 redirect_from: /blog/data-science-assessment-challenges/

--- a/_posts/2017/12/2017-12-11-reponse-to-null-effects.md
+++ b/_posts/2017/12/2017-12-11-reponse-to-null-effects.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: [ "Karen Word"]
 
 --- 

--- a/_posts/2017/12/2017-12-12-exec-council-announce.md
+++ b/_posts/2017/12/2017-12-12-exec-council-announce.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kate Hertweck"]
 redirect_from: /blog/exec-council-announce/
 --- 

--- a/_posts/2017/12/2017-12-13-csa-award-avdw.md
+++ b/_posts/2017/12/2017-12-13-csa-award-avdw.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Christina Koch", "Kate Hertweck"]
 redirect_from: /blog/csa-award-avdw/
 --- 

--- a/_posts/2017/12/2017-12-19-frb_carpentry.md
+++ b/_posts/2017/12/2017-12-19-frb_carpentry.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Alice Allen"]
 redirect_from: /blog/frb_carpentry/
 --- 

--- a/_posts/2018/01/2018-01-02-waldman-fave.md
+++ b/_posts/2018/01/2018-01-02-waldman-fave.md
@@ -4,7 +4,7 @@ authors: ["Simon Waldman"]
 title: "My Favorite Tool - QGIS"
 date: 2018-01-02
 time: "00:00:00"
-tags: [ "Research tools", "Community", "GIS", "Geographic Information Systems", "Software Carpentry"]
+tags: [ "Research Tools", "Community", "GIS", "Geographic Information Systems", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/01/2018-01-08-fave_update.md
+++ b/_posts/2018/01/2018-01-08-fave_update.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Fourteen and Counting - People's Favorite Tools"
 date: 2018-01-08
 time: "09:00:00"
-tags: ["Python", "IPython", "Jupyter", "Teaching", "R", "Git", "GitHub", "Videoconferencing", "emacs", "RStudio", "rasterio", "GIS", "Coding", "Software Carpentry"]
+tags: ["Python", "IPython", "Jupyter", "Teaching", "R", "Git", "GitHub", "Videoconferencing", "Emacs", "RStudio", "rasterio", "GIS", "Coding", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/01/2018-01-10-teach-prac-01_dc.md
+++ b/_posts/2018/01/2018-01-10-teach-prac-01_dc.md
@@ -9,7 +9,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/teach-prac-01/
 --- 

--- a/_posts/2018/01/2018-01-11-exec-dir-message.md
+++ b/_posts/2018/01/2018-01-11-exec-dir-message.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal"]
 --- 
 

--- a/_posts/2018/01/2018-01-14-assign-instructors.md
+++ b/_posts/2018/01/2018-01-14-assign-instructors.md
@@ -4,7 +4,7 @@ authors: ["Maneesha Sane"]
 title: "How do instructors get placed at workshops?"
 date: 2018-01-14
 time: "00:00:00"
-tags: [ "Instructors", "workshops", "Placement", "Software Carpentry"]
+tags: [ "Instructors", "Workshops", "Placement", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/01/2018-01-14-sauze-mcedit.md
+++ b/_posts/2018/01/2018-01-14-sauze-mcedit.md
@@ -4,7 +4,7 @@ authors: ["Colin Sauze"]
 title: "My Favorite Tool - Midnight Commander"
 date: 2018-01-14
 time: "00:00:00"
-tags: [ "Research tools", "Text", "Text editors", "Software Carpentry"]
+tags: [ "Research Tools", "Text", "Text Editors", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/01/2018-01-15-datacarpentry-looking-forward-looking-back.md
+++ b/_posts/2018/01/2018-01-15-datacarpentry-looking-forward-looking-back.md
@@ -7,7 +7,7 @@ categories:
   - blog
 show_meta: true
 comments: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: [Karen Cranston, Hilmar Lapp, Aleksandra Pawlik, Karthik Ram, Tracy Teal, Ethan White]
 redirect_from: /blog/datacarpentry-looking-forward-looking-back/
 --- 

--- a/_posts/2018/01/2018-01-30-fiscal-sponsor-transition_dc.md
+++ b/_posts/2018/01/2018-01-30-fiscal-sponsor-transition_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal", "Gina Helfrich"]
 redirect_from: /blog/fiscal-sponsor-transition/
 --- 

--- a/_posts/2018/02/2018-02-02-library-carpentry-repost.md
+++ b/_posts/2018/02/2018-02-02-library-carpentry-repost.md
@@ -9,7 +9,7 @@ Categories:
 comments: true
 show_meta: true
 date: 2018-02-02
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["John Chodacki", "Tracy Teal"]
 redirect_from: /blog/library-carpentry-repost/
 --- 

--- a/_posts/2018/02/2018-02-07-champions-call.md
+++ b/_posts/2018/02/2018-02-07-champions-call.md
@@ -4,7 +4,7 @@ authors: ["Jonah Duckles"]
 title: "Carpentry Champions Call"
 date: 2018-02-07
 time: "00:00:00"
-tags: ["Community", "Community building", "Champions", "Software Carpentry"]
+tags: ["Community", "Community Building", "Champions", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/02/2018-02-07-new-carpentries-logo.md
+++ b/_posts/2018/02/2018-02-07-new-carpentries-logo.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/new-carpentries-logo/
 --- 

--- a/_posts/2018/02/2018-02-12-curriculum-dev-scaling.md
+++ b/_posts/2018/02/2018-02-12-curriculum-dev-scaling.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal"]
 redirect_from: /blog/curriculum-dev-scaling/
 --- 

--- a/_posts/2018/02/2018-02-14-valerie-aurora-keynote_dc.md
+++ b/_posts/2018/02/2018-02-14-valerie-aurora-keynote_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Belinda Weaver"]
 redirect_from: /blog/valerie-aurora-keynote/
 --- 

--- a/_posts/2018/02/2018-02-15-Mentoring-Groups-Virtual-Showcase.md
+++ b/_posts/2018/02/2018-02-15-Mentoring-Groups-Virtual-Showcase.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan"]
 redirect_from: /blog/Mentoring-Groups-Virtual-Showcase/
 --- 

--- a/_posts/2018/02/2018-02-15-woodbridge-fave-docker.md
+++ b/_posts/2018/02/2018-02-15-woodbridge-fave-docker.md
@@ -4,7 +4,7 @@ authors: ["Mark Woodbridge"]
 title: "My Favorite Tool - Docker"
 date: 2018-02-15
 time: "00:00:00"
-tags: [ "Research tools", "Virtualization", "Containers", "Software Testing", "Software Carpentry"]
+tags: [ "Research Tools", "Virtualization", "Containers", "Software Testing", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/03/2018-03-05-curriculum-advisory.md
+++ b/_posts/2018/03/2018-03-05-curriculum-advisory.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Erin Becker", "Christina Koch"]
 redirect_from: /blog/curriculum-advisory/
 --- 

--- a/_posts/2018/03/2018-03-07-bug-bbq_dc.md
+++ b/_posts/2018/03/2018-03-07-bug-bbq_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["François Michonneau", "Erin Becker"]
 redirect_from: /blog/2018-03-07-bug-bbq/
 --- 

--- a/_posts/2018/03/2018-03-08-call-for-volunteers-coc_dc.md
+++ b/_posts/2018/03/2018-03-08-call-for-volunteers-coc_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan", "Tracy Teal", "Erin Becker"]
 redirect_from: /blog/call-for-volunteers-coc/
 --- 

--- a/_posts/2018/03/2018-03-12-next-round-mentoring_dc.md
+++ b/_posts/2018/03/2018-03-12-next-round-mentoring_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan"]
 redirect_from: /blog/next-round-mentoring/
 --- 

--- a/_posts/2018/03/2018-03-13-african_task-force.md
+++ b/_posts/2018/03/2018-03-13-african_task-force.md
@@ -4,7 +4,7 @@ authors: ["Caroline F. Ajilogba", "Mesfin Diro", "Erika Mias", "Lactatia Motsuku
 title: "Revival of the African Task Force"
 date: 2018-03-13
 time: "08:00:00"
-tags: ["Community", "Africa", "Task Forces", "Software Carpentry"]
+tags: ["Community", "Africa", "Task Force", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/03/2018-03-14-adding-new-trainers.md
+++ b/_posts/2018/03/2018-03-14-adding-new-trainers.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Karen Word", "Erin Becker"]
 redirect_from: /blog/adding-new-trainers/
 --- 

--- a/_posts/2018/03/2018-03-20-tractenberg-summary.md
+++ b/_posts/2018/03/2018-03-20-tractenberg-summary.md
@@ -4,7 +4,7 @@ authors: ["Marianne Corvellec", "Karen Word"]
 title: "Webinar with Rochelle Tractenberg: Debrief"
 date: 2018-03-20
 time: "08:00:00"
-tags: [ "webinars", "Assessment", "Assessment network", "Software Carpentry"]
+tags: [ "Webinars", "Assessment", "Assessment network", "Software Carpentry"]
 ---
 
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>

--- a/_posts/2018/03/2018-03-20-tractenberg-summary_dc.md
+++ b/_posts/2018/03/2018-03-20-tractenberg-summary_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Marianne Corvellec", "Karen Word"]
 redirect_from: /blog/tractenberg-summary/
 --- 

--- a/_posts/2018/04/2018-04-03-bug-bbq-how-to-be-involved.md
+++ b/_posts/2018/04/2018-04-03-bug-bbq-how-to-be-involved.md
@@ -10,7 +10,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["François Michonneau"]
 --- 
 

--- a/_posts/2018/04/2018-04-04-mentoring-groups-still-open.md
+++ b/_posts/2018/04/2018-04-04-mentoring-groups-still-open.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Kari L. Jordan"]
 redirect_from: /blog/mentoring-groups-still-open/
 --- 

--- a/_posts/2018/04/2018-04-05-github-labels.md
+++ b/_posts/2018/04/2018-04-05-github-labels.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["François Michonneau"]
 redirect_from: /blog/github-labels/
 --- 

--- a/_posts/2018/04/2018-04-11-launch-handbook_dc.md
+++ b/_posts/2018/04/2018-04-11-launch-handbook_dc.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal", "Maneesha Sane", "Belinda Weaver"]
 redirect_from: /blog/launch-handbook/
 --- 

--- a/_posts/2018/04/2018-04-12-announce-lc-hire.md
+++ b/_posts/2018/04/2018-04-12-announce-lc-hire.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal", "John Chodacki", "Chris Erdmann",  "Belinda Weaver"]
 redirect_from: /blog/announce-lc-hire/
 --- 

--- a/_posts/2018/04/2018-04-12-volunteers-wanted.md
+++ b/_posts/2018/04/2018-04-12-volunteers-wanted.md
@@ -7,7 +7,7 @@ categories:
    - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["SherAaron Hurt"]
 redirect_from: /blog/volunteers-wanted/
 --- 

--- a/_posts/2018/04/2018-04-25-launch-website.md
+++ b/_posts/2018/04/2018-04-25-launch-website.md
@@ -9,7 +9,7 @@ categories:
     - blog
 comments: true
 show_meta: true
-tags: ["", "Data Carpentry"]
+tags: ["Data Carpentry"]
 authors: ["Tracy Teal", "Belinda Weaver"]
 redirect_from: /blog/launch-website/
 --- 

--- a/_posts/2018/08/2018-08-07-what-is-a-workshop.md
+++ b/_posts/2018/08/2018-08-07-what-is-a-workshop.md
@@ -5,7 +5,7 @@ title: "What constitutes a Library Carpentry workshop?"
 teaser: "What is considered a Library Carpentry workshop vs a roadshow"
 date: 2018-08-07
 time: "09:00:00"
-tags: ["Library Carpentry", "Workshop", "Overview", "Roadshow", "Training", "Curriculum"]
+tags: ["Library Carpentry", "Workshops", "Overview", "Roadshow", "Training", "Curriculum"]
 category: ["blog"]
 --- 
 

--- a/_posts/2018/09/2018-09-05-report-from-calgary-workshops.md
+++ b/_posts/2018/09/2018-09-05-report-from-calgary-workshops.md
@@ -4,7 +4,7 @@ authors: ["Chris Erdmann"]
 title: "Report back from University of Calgary Libraries"
 teaser: "Workshop and instructor training for librarians"
 date: 2018-09-05
-tags: ["University of Calgary", "Library Carpentry", "The Carpentries", "Instructor Training", "Workshop"]
+tags: ["University of Calgary", "Library Carpentry", "The Carpentries", "Instructor Training", "Workshops"]
 category: ["blog"]
 --- 
 

--- a/_posts/2018/09/2018-09-12-data-in-the-desert.md
+++ b/_posts/2018/09/2018-09-12-data-in-the-desert.md
@@ -4,7 +4,7 @@ authors: ["Jeff Oliver"]
 title: "Data in the desert"
 teaser: "Library Carpentry workshop at the University of Arizona"
 date: 2018-09-12
-tags: ["University of Arizona", "Library Carpentry", "The Carpentries", "Workshop"]
+tags: ["University of Arizona", "Library Carpentry", "The Carpentries", "Workshops"]
 category: ["blog"]
 ---
 

--- a/_posts/2022/02/2022-02-16-online-teaching-KCL.md
+++ b/_posts/2022/02/2022-02-16-online-teaching-KCL.md
@@ -5,7 +5,7 @@ teaser: "King's College London Carpentries Instructor Team share their experienc
 title: "Our tips and tricks for online workshop teaching"
 date: 2022-03-01
 time: "09:00:00"
-tags: ["Teaching", "Carpentries workshops"]
+tags: ["Teaching", "Carpentries Workshops"]
 ---
 
 ## Who we are

--- a/_posts/2022/11/2022-11-28-accathon.md
+++ b/_posts/2022/11/2022-11-28-accathon.md
@@ -5,7 +5,7 @@ teaser: "With support from the community, we added alt text to 55 images across 
 title: "Community Helps Add Alt Texts to our Lesson Images"
 date: 2022-11-23
 time: "09:00:00"
-tags: ["accessibility"]
+tags: ["Accessibility"]
 ---
 
 In early September, Brynn Elliott, Accessibility Manager for The Carpentries hosted two Themed Discussions for the community focused on improving accessibility of our lessons through improving alt text on images. The group started off with an overview of what alt text is, why it is important, and how to add it to images in our lessons.## What is alt text?

--- a/_posts/2022/12/2022-12-05-ARDC-carpentries.md
+++ b/_posts/2022/12/2022-12-05-ARDC-carpentries.md
@@ -5,7 +5,7 @@ teaser: "The ARDC’s Liz Stokes spoke to Carpentries workshop instructors and h
 title: "I Can’t Believe I Survived Without It: Learning Data and Software Skills with The Carpentries"
 date: 2022-12-05
 time: "09:00:00"
-tags: ["community"]
+tags: ["Community"]
 ---
 
 This blog post was [originally published](https://ardc.edu.au/article/i-cant-believe-i-survived-without-it-learning-data-and-software-skills-with-the-carpentries/) on 15 November on the Australian Research Data Commons blog.

--- a/_posts/2022/12/2022-12-14-carpentries-offline-carpentrycon.md
+++ b/_posts/2022/12/2022-12-14-carpentries-offline-carpentrycon.md
@@ -5,7 +5,7 @@ teaser: "Updates on the The CarpentriesOffline project"
 title: "CarpentriesOffline — CarpentryCon 2022 feedback and call for help"
 date: 2022-12-14
 time: "09:00:00"
-tags: ["community"]
+tags: ["Community"]
 ---
 
 This blog post was [originally published](https://medium.com/@jannetta/carpentriesoffline-carpentrycon-2022-feedback-and-call-for-help-3379345f07cf) on 12 December on Medium.


### PR DESCRIPTION
Clean up blog post tags as some tags were listed multiple times due to typos, variations on capitalization, pluralization, etc.  Blog post tags could still use a comprehensive review - this PR only makes obvious changes.