### PR TITLE
make corporate pricing more visible

### DIFF
--- a/pages/become-instructor.md
+++ b/pages/become-instructor.md
@@ -65,13 +65,15 @@ Individuals not affiliated with Member organisations can purchase seats in Instr
 
 Individuals and organisations may pay a fee to gain access to Instructor Training. Once invoiced, we will create a unique registration code that trainees can use to access registration for any event on our quarterly [Instructor Training Calendar](https://carpentries.github.io/instructor-training/training_calendar#upcoming-instructor-training).
 
-|                     | Instructor Training Seat Fee (USD) |
+|                     | Instructor Training Seat Fee (USD)&dagger; |
 | ------------------- | ---------------------------------- |
 | High Income         | \$1,500                            |
 | Upper-Middle Income | \$1,125                            |
 | Lower-Middle Income | \$750                              |
 | Low Income          | \$375                              |
 
-The per seat fee is dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html). All fees listed are in USD and represent costs for not-for-profit or academic organisations. Costs for for-profit organisations are four times the fee listed for not-for-profit organisations.
+<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i></p>
+
+The per seat fee is dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html).
 
 If you are seeking to train six (6) or more individuals, please check out our [Membership page]({{site.url}}/membership/) as the rate may be lower.

--- a/pages/lesson-development-training.md
+++ b/pages/lesson-development-training.md
@@ -79,16 +79,16 @@ trainees will learn principles and practices
 to ensure they can continue to collaborate effectively on the project.
 
 
-## Pricing&dagger;
+## Pricing
 
-| Income Level | Base Fee (2 people, USD) | Additional Person Fee (per person, USD) |
+| Income Level | Base Fee (2 people, USD)&dagger; | Additional Person Fee (per person, USD)&dagger; |
 |--------------|-------------------------:|----------------------------------------:|
 | High         | $5,000                   | $1,000                                  |
 | Upper middle | $3,750                   | $750                                    |
 | Lower middle | $2,500                   | $500                                    |
 | Low          | $1,250                   | $250                                    |
 
-<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i>
+<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i></p>
 
 The base price gives access to the training to two people who will
 work together as a team on a lesson during the training.

--- a/pages/lesson-development-training.md
+++ b/pages/lesson-development-training.md
@@ -79,7 +79,7 @@ trainees will learn principles and practices
 to ensure they can continue to collaborate effectively on the project.
 
 
-## Pricing
+## Pricing&dagger;
 
 | Income Level | Base Fee (2 people, USD) | Additional Person Fee (per person, USD) |
 |--------------|-------------------------:|----------------------------------------:|
@@ -88,6 +88,8 @@ to ensure they can continue to collaborate effectively on the project.
 | Lower middle | $2,500                   | $500                                    |
 | Low          | $1,250                   | $250                                    |
 
+<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i>
+
 The base price gives access to the training to two people who will
 work together as a team on a lesson during the training.
 Additional team members can be added for an additional 20% of the base price per person.
@@ -95,8 +97,6 @@ Additional team members can be added for an additional 20% of the base price per
 The fee is dependent on the purchasing organisation’s geographic location,
 according to [the World Bank’s gross national income categorisation][income-categorisation]
 (reflected by the "Income Level" column in the table above).
-All fees listed are in USD and represent costs for not-for-profit or academic organisations.
-Costs for for-profit organisations are four times the fee listed for not-for-profit organisations.
 
 ## Register
 

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -10,8 +10,7 @@ excerpt: A Member Organisation is an organisation which has made a commitment to
 <p>We offer five Membership levels, based on training activities expected annually. The cost for each Membership level is dependent on the
 purchasing organisation&#39;s geographic location, according to the
 <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s</a> gross national income 
-categorisation. All fees listed are in USD and represent costs for not-for-profit organisations. 
-Costs for for-profit organisations are four times the price for not-for-profit organisations. </p>
+categorisation.</p>
 
 
 <table>
@@ -43,7 +42,7 @@ Costs for for-profit organisations are four times the price for not-for-profit o
     <td>0</td>
   </tr>
   <tr>
-    <th colspan=6>Membership Fee (USD Annual) per <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s income categorisation</a></th>
+    <th colspan=6>Membership Fee (USD Annual)&dagger; per <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s income categorisation</a></th>
   </tr>
   <tr>
     <th>High income</th>
@@ -80,6 +79,7 @@ Costs for for-profit organisations are four times the price for not-for-profit o
 </table> 
 
 <p><i>*This tier is customizable based on organizational priorities.</i></p>
+<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i>
 
 <p>In addition to the benefits above, all Memberships include:</p>
 <ul>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -42,7 +42,7 @@ categorisation.</p>
     <td>0</td>
   </tr>
   <tr>
-    <th colspan=6>Membership Fee (USD Annual)&dagger; per <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank&#39;s income categorisation</a></th>
+    <th colspan=6>Membership Fee (USD Annual)&dagger;</th>
   </tr>
   <tr>
     <th>High income</th>

--- a/pages/workshops.html
+++ b/pages/workshops.html
@@ -288,11 +288,11 @@ Our instructors are volunteers and are not paid for their time teaching. Therefo
 <li>The administration fee is used to support staff time with this partnership. You will be provided with exceptional customer service and timely support from our Workshops and Instruction Team and Regional Coordinators. </li>
 </ul>
 
-<p>The workshop fee is dependent on the purchasing organisation's geographic location, according to the <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank's gross national income categorisation</a>. All fees listed are in USD and represent costs for not-for-profit or academic organisations. Costs for for-profit organisations are four times the fee listed for not-for-profit organisations.</p>
+<p>The workshop fee is dependent on the purchasing organisation's geographic location, according to the <a href="https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html">World Bank's gross national income categorisation</a>.</p>
 <table>
   <tr>
       <th></th>
-      <th>Workshop Administration Fee (USD)</th>
+      <th>Workshop Administration Fee (USD)&dagger;</th>
   </tr>
   <tr>
     <th>High income</th>
@@ -311,6 +311,8 @@ Our instructors are volunteers and are not paid for their time teaching. Therefo
     <td>$750</td>
   </tr>
 </table> 
+
+<p><i>&dagger;Non-profit fees shown. For-profit organisation fees are 4x listed price.</i>
 
 
 <h3>Workshop Administration Financial Support</h3>


### PR DESCRIPTION
Moves text describing for-profit pricing structure from paragraph body to table note. This PR makes this change for the following pages: 
- [x] /membership/
- [x] /workshops/
- [x] /become-instructor/
- [x] /lesson-development-training/