### PR TITLE
Remove link to grants

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -35,7 +35,7 @@ by a <a href="{{site.url}}/governance">Board of Directors</a>.
 
 #### How is The Carpentries Funded?
 
-The Carpentries revenue sources include [membership fees]({{site.url}}/membership), [grants and donations]({{site.url}}/grants), Workshops and Instructor Training fees, sponsorships, and individual donations. These income streams support the work of the Core Team, workshop & lesson infrastructure, CarpentryCon, and our continued work towards The Carpentries mission. The Carpentries [Annual Financial Reports]({{site.url}}/reports) provide more detailed information about our annual income and expenditures.
+The Carpentries revenue sources include [membership fees]({{site.url}}/membership), grants and donations, Workshops and Instructor Training fees, sponsorships, and individual donations. These income streams support the work of the Core Team, workshop & lesson infrastructure, CarpentryCon, and our continued work towards The Carpentries mission. The Carpentries [Annual Financial Reports]({{site.url}}/reports) provide more detailed information about our annual income and expenditures.
 
 Individuals and organisations are welcome to <a href="{{site.fundraising_link}}">donate to The Carpentries</a> using the online portal. Organisations interested in supporting The Carpentries are also encouraged to read about becoming a [Sponsor Organisation]({{site.url}}/sponsorship).
 


### PR DESCRIPTION
There is a link to "grants" on the about page that links to a non-existent page.