### PR TITLE
CCHD24 registration announcement post

### DIFF
--- a/_posts/2024/06/2024-06-24-cchd24-registration-programme.md
+++ b/_posts/2024/06/2024-06-24-cchd24-registration-programme.md
@@ -1,0 +1,26 @@
+---
+layout: page
+authors: ["The CCHD24 Organising Committee"]
+teaser: "A draft programme has also been updated for the November community event in Germany."
+title: "Registration Open for CarpentryConnect Heidelberg"
+date: 2024-06-24
+time: "09:00:00"
+tags: ["CarpentryConnect", "Events"]
+---
+
+**[Registration has opened for the BioNT Community Event & CarpentryConnect Heidelberg 2024!](https://biont-training.eu/event-details/CarpentryConnect2024)** Register to participate remotely or in-person before 15th September.
+
+* [Register for remote participation](https://embl.ungerboeck.com/PROD/emc00/register.aspx?aat=MulIMw2DfZ0Yc2qDnXZcy7sGZfzOLQzpnxqa6MyFaWI%3d)
+* [Register for in-person participation](https://embl.ungerboeck.com/PROD/emc00/register.aspx?aat=eCafbiTSn12L5SBImMxFvDMFEL3WSolrYmTdZdhLJOw%3d)
+
+As a reminder, this regional event for members of The Carpentries and [BioNT](https://biont-training.eu/) communities will include a diverse range of interactive and collaborative sessions. [The event programme](https://biont-training.eu/event-details/conference-programme) has been updated to include more information about the sessions and schedule.
+
+The event will take place 12-14 November 2024, online and at [EMBL Heidelberg](https://www.embl.org/sites/heidelberg/).
+
+We understand the importance of making this event accessible to everyone who wishes to participate, so we are offering an [Inclusivity Ticket](https://survey.bio-it.embl.de/195458?) to waive the registration fee for 10 individuals with limited budgets (deadline: July 12th).
+
+For more information, visit [the event website](https://biont-training.eu/event-details/CarpentryConnect2024) and review our previous posts on the topic:
+
+1. [_Exciting updates from the CarpentryConnect Heidelberg 2024 organising committee_](https://carpentries.org/blog/2024/05/cchd2024-updates-from-the-organising-committee/), where we announced the three keynote speakers: Radhika S Khetani, Yanina Bellini Saibene, and Malvika Sharan.
+2. [_Proposal submission opens for CCHD24_](https://carpentries.org/blog/2024/02/cchd24-call-for-proposals/), where we provided more information about the theme of the event and the kinds of submissions we were hoping to receive.
+3. [_Join us for CarpentryConnect Heidelberg 2024!_](https://carpentries.org/blog/2024/01/announcing-cchd24/) The initial announcement post, which presents further information including our motivations for the event.

--- a/_posts/2024/06/2024-06-24-cchd24-registration-programme.md
+++ b/_posts/2024/06/2024-06-24-cchd24-registration-programme.md
@@ -3,7 +3,7 @@ layout: page
 authors: ["The CCHD24 Organising Committee"]
 teaser: "A draft programme has also been updated for the November community event in Germany."
 title: "Registration Open for CarpentryConnect Heidelberg"
-date: 2024-06-24
+date: 2024-06-25
 time: "09:00:00"
 tags: ["CarpentryConnect", "Events"]
 ---


### PR DESCRIPTION
A post announcing registration opening and an updated provisional programme for CarpentryConnect Heidelberg 2024.